### PR TITLE
Fix warnings and code cleanup

### DIFF
--- a/Wasm2IL/CString.cs
+++ b/Wasm2IL/CString.cs
@@ -27,7 +27,7 @@ public ref struct CString
         return new CString(heap, offset);
     }
 
-    public string ToString()
+    public override string ToString()
     {
         var span = heap.Slice(offset, Length);
         return System.Text.Encoding.UTF8.GetString(span);

--- a/Wasm2IL/Program.cs
+++ b/Wasm2IL/Program.cs
@@ -8,9 +8,8 @@ namespace Wasm2IL
         public static void Main()
         {
             var args = Environment.GetCommandLineArgs();
-            string run = null;
-            string file = null;
-            bool help = false;
+            string? run = null;
+            string? file = null;
             for(int i = 0; i < args.Length; i++)
             {
                 if (args[i] == "--run")
@@ -18,7 +17,10 @@ namespace Wasm2IL
                     run = args[i + 1];
                     i += 1;
                 }else if (args[i] == "--help")
-                    help = true;
+                {
+                    // Help flag handled but not implemented yet
+                    continue;
+                }
                 else
                 {
                     file = args[i];
@@ -27,13 +29,10 @@ namespace Wasm2IL
 
             if (file == null)
                 throw new ArgumentException("File not specified", "--file");
-            
+
             string dllName = Path.ChangeExtension(file, ".dll");
-            if (file != null)
-            {
-                var fstr = File.OpenRead(file);
-                new Transformer().Transform(fstr, Path.GetFileNameWithoutExtension(file), dllName);
-            }
+            var fstr = File.OpenRead(file);
+            new Transformer().Transform(fstr, Path.GetFileNameWithoutExtension(file), dllName);
 
             if (run != null)
             {  

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -9,7 +9,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 using Wasm;
-using Wasm2CIl.Utils;
+using Wasm2IL.Utils;
 using Wasm2IL.Dwarf;
 using AssemblyDefinition = Mono.Cecil.AssemblyDefinition;
 using FieldAttributes = Mono.Cecil.FieldAttributes;

--- a/Wasm2IL/Utils/Assert.cs
+++ b/Wasm2IL/Utils/Assert.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Wasm2IL
 {
     static class Assert

--- a/Wasm2IL/Utils/IlExtensions.cs
+++ b/Wasm2IL/Utils/IlExtensions.cs
@@ -2,7 +2,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Mono.Cecil.Cil;
 
-namespace Wasm2CIl.Utils;
+namespace Wasm2IL.Utils;
 
 public static class IlExtensions
 {

--- a/Wasm2IL/Utils/Log.cs
+++ b/Wasm2IL/Utils/Log.cs
@@ -1,4 +1,4 @@
-namespace Wasm2CIl.Utils;
+namespace Wasm2IL.Utils;
 
 internal class Log
 {

--- a/Wasm2IL/Utils/Utils.cs
+++ b/Wasm2IL/Utils/Utils.cs
@@ -1,10 +1,10 @@
 using System.Reflection;
 
-namespace Wasm2CIl.Utils;
+namespace Wasm2IL.Utils;
 
 public static class Utils
 {
-    public static MethodInfo GetMethod(this List<Type> types, string name)
+    public static MethodInfo? GetMethod(this List<Type> types, string name)
     {
         foreach (var t in types)
         {
@@ -14,5 +14,5 @@ public static class Utils
 
         return null;
     }
-    
+
 }

--- a/Wasm2IL/WasmAttribute.cs
+++ b/Wasm2IL/WasmAttribute.cs
@@ -5,7 +5,7 @@ public class WasmAttribute : Attribute
     /// <summary>
     /// If export name is null, just use the name of the method.
     /// </summary>
-    public string ExportName { get; set; }
+    public string? ExportName { get; set; }
     public WasmAttribute(string importExportName)
     {
         ExportName = importExportName;
@@ -13,6 +13,6 @@ public class WasmAttribute : Attribute
 
     public WasmAttribute()
     {
-            
+
     }
 }


### PR DESCRIPTION
- Fix namespace typo: Wasm2CIl -> Wasm2IL in Log.cs, Utils.cs, and Transformer.cs
- Add nullable reference type annotations to Program.cs, Utils.cs, and WasmAttribute.cs
- Remove unused 'help' variable in Program.cs
- Remove redundant null check in Program.cs after exception throw
- Remove unused using statement in Assert.cs
- Add override keyword to CString.ToString() method
- Clean up whitespace and formatting issues