### PR TITLE
Add assembly optimization for constant propagation

### DIFF
--- a/Wasm2IL.UnitTests/TestAlgebraicSimplifier.cs
+++ b/Wasm2IL.UnitTests/TestAlgebraicSimplifier.cs
@@ -36,9 +36,10 @@ public class TestAlgebraicSimplifier
     }
 
     [Test]
-    public void TestAddZeroRight()
+    public void TestAddZeroRight_NotOptimized()
     {
-        // Test: a + 0 => a
+        // a + 0 is NOT optimized because 'add' is used for pointer arithmetic
+        // and we can't determine the type of 'a' without type tracking
         var method = CreateMethod("TestAddZeroRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
@@ -47,21 +48,19 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
-        Assert.AreEqual(4, method.Body.Instructions.Count);
+        int originalCount = method.Body.Instructions.Count;
 
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // Should be simplified to: ldarg.0, ret
-        Assert.AreEqual(2, method.Body.Instructions.Count);
-        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
-        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
+        // Should NOT be simplified due to pointer arithmetic concerns
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
     }
 
     [Test]
-    public void TestAddZeroLeft()
+    public void TestAddZeroLeft_NotOptimized()
     {
-        // Test: 0 + a => a
+        // 0 + a is NOT optimized because 'add' is used for pointer arithmetic
         var method = CreateMethod("TestAddZeroLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
@@ -70,21 +69,19 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
-        Assert.AreEqual(4, method.Body.Instructions.Count);
+        int originalCount = method.Body.Instructions.Count;
 
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // Should be simplified to: ldarg.0, ret
-        Assert.AreEqual(2, method.Body.Instructions.Count);
-        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
-        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
+        // Should NOT be simplified due to pointer arithmetic concerns
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
     }
 
     [Test]
-    public void TestSubZero()
+    public void TestSubZero_NotOptimized()
     {
-        // Test: a - 0 => a
+        // a - 0 is NOT optimized because 'sub' is used for pointer arithmetic
         var method = CreateMethod("TestSubZero", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
@@ -93,11 +90,13 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Sub);
         il.Emit(OpCodes.Ret);
 
+        int originalCount = method.Body.Instructions.Count;
+
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        Assert.AreEqual(2, method.Body.Instructions.Count);
-        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+        // Should NOT be simplified due to pointer arithmetic concerns
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
     }
 
     [Test]
@@ -348,9 +347,9 @@ public class TestAlgebraicSimplifier
     }
 
     [Test]
-    public void TestI64AddZero()
+    public void TestI64AddZero_NotOptimized()
     {
-        // Test: a + 0L => a (i64)
+        // a + 0L is NOT optimized for i64 (same pointer arithmetic concerns as i32)
         var method = CreateMethod("TestI64AddZero", _module.TypeSystem.Int64, _module.TypeSystem.Int64);
         var il = method.Body.GetILProcessor();
 
@@ -359,11 +358,13 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
+        int originalCount = method.Body.Instructions.Count;
+
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        Assert.AreEqual(2, method.Body.Instructions.Count);
-        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+        // Should NOT be simplified due to pointer arithmetic concerns
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
     }
 
     [Test]
@@ -464,13 +465,14 @@ public class TestAlgebraicSimplifier
     [Test]
     public void TestChainedSimplification()
     {
-        // Test: (a + 0) * 1 => a
+        // Test: (a | 0) * 1 => a
+        // Using | instead of + since + is not optimized due to pointer arithmetic
         var method = CreateMethod("TestChained", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Or);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Mul);
         il.Emit(OpCodes.Ret);
@@ -488,7 +490,7 @@ public class TestAlgebraicSimplifier
     [Test]
     public void TestConstantFoldingThenSimplification()
     {
-        // Test: a + (1 - 1) => a + 0 => a
+        // Test: a | (1 - 1) => a | 0 => a
         // This tests that constant folding and algebraic simplification work together
         var method = CreateMethod("TestCombined", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
@@ -497,7 +499,7 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Sub);
-        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Or);
         il.Emit(OpCodes.Ret);
 
         Assert.AreEqual(6, method.Body.Instructions.Count);
@@ -505,7 +507,7 @@ public class TestAlgebraicSimplifier
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // After constant folding: a, 0, add, ret
+        // After constant folding: a, 0, or, ret
         // After algebraic simplification: a, ret
         Assert.AreEqual(2, method.Body.Instructions.Count);
         Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);

--- a/Wasm2IL.UnitTests/TestAlgebraicSimplifier.cs
+++ b/Wasm2IL.UnitTests/TestAlgebraicSimplifier.cs
@@ -36,10 +36,9 @@ public class TestAlgebraicSimplifier
     }
 
     [Test]
-    public void TestAddZeroRight_NotOptimized()
+    public void TestAddZeroRight()
     {
-        // a + 0 is NOT optimized because 'add' is used for pointer arithmetic
-        // and we can't determine the type of 'a' without type tracking
+        // Test: a + 0 => a
         var method = CreateMethod("TestAddZeroRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
@@ -48,19 +47,21 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
-        int originalCount = method.Body.Instructions.Count;
+        Assert.AreEqual(4, method.Body.Instructions.Count);
 
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // Should NOT be simplified due to pointer arithmetic concerns
-        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+        // Should be simplified to: ldarg.0, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
     }
 
     [Test]
-    public void TestAddZeroLeft_NotOptimized()
+    public void TestAddZeroLeft()
     {
-        // 0 + a is NOT optimized because 'add' is used for pointer arithmetic
+        // Test: 0 + a => a
         var method = CreateMethod("TestAddZeroLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
@@ -69,19 +70,21 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
-        int originalCount = method.Body.Instructions.Count;
+        Assert.AreEqual(4, method.Body.Instructions.Count);
 
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // Should NOT be simplified due to pointer arithmetic concerns
-        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+        // Should be simplified to: ldarg.0, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
     }
 
     [Test]
-    public void TestSubZero_NotOptimized()
+    public void TestSubZero()
     {
-        // a - 0 is NOT optimized because 'sub' is used for pointer arithmetic
+        // Test: a - 0 => a
         var method = CreateMethod("TestSubZero", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
@@ -90,13 +93,11 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Sub);
         il.Emit(OpCodes.Ret);
 
-        int originalCount = method.Body.Instructions.Count;
-
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // Should NOT be simplified due to pointer arithmetic concerns
-        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
     }
 
     [Test]
@@ -347,9 +348,9 @@ public class TestAlgebraicSimplifier
     }
 
     [Test]
-    public void TestI64AddZero_NotOptimized()
+    public void TestI64AddZero()
     {
-        // a + 0L is NOT optimized for i64 (same pointer arithmetic concerns as i32)
+        // Test: a + 0L => a (i64)
         var method = CreateMethod("TestI64AddZero", _module.TypeSystem.Int64, _module.TypeSystem.Int64);
         var il = method.Body.GetILProcessor();
 
@@ -358,13 +359,11 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
-        int originalCount = method.Body.Instructions.Count;
-
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // Should NOT be simplified due to pointer arithmetic concerns
-        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
     }
 
     [Test]
@@ -465,14 +464,13 @@ public class TestAlgebraicSimplifier
     [Test]
     public void TestChainedSimplification()
     {
-        // Test: (a | 0) * 1 => a
-        // Using | instead of + since + is not optimized due to pointer arithmetic
+        // Test: (a + 0) * 1 => a
         var method = CreateMethod("TestChained", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Mul);
         il.Emit(OpCodes.Ret);
@@ -490,7 +488,7 @@ public class TestAlgebraicSimplifier
     [Test]
     public void TestConstantFoldingThenSimplification()
     {
-        // Test: a | (1 - 1) => a | 0 => a
+        // Test: a + (1 - 1) => a + 0 => a
         // This tests that constant folding and algebraic simplification work together
         var method = CreateMethod("TestCombined", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
         var il = method.Body.GetILProcessor();
@@ -499,7 +497,7 @@ public class TestAlgebraicSimplifier
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Sub);
-        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ret);
 
         Assert.AreEqual(6, method.Body.Instructions.Count);
@@ -507,7 +505,7 @@ public class TestAlgebraicSimplifier
         var optimizer = new ILOptimizer(method.Body);
         optimizer.Optimize();
 
-        // After constant folding: a, 0, or, ret
+        // After constant folding: a, 0, add, ret
         // After algebraic simplification: a, ret
         Assert.AreEqual(2, method.Body.Instructions.Count);
         Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);

--- a/Wasm2IL.UnitTests/TestAlgebraicSimplifier.cs
+++ b/Wasm2IL.UnitTests/TestAlgebraicSimplifier.cs
@@ -1,0 +1,533 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Wasm2IL.Optimization;
+
+namespace Wasm2IL.UnitTests;
+
+[TestFixture]
+public class TestAlgebraicSimplifier
+{
+    private AssemblyDefinition _assembly;
+    private TypeDefinition _type;
+    private ModuleDefinition _module;
+
+    public TestAlgebraicSimplifier()
+    {
+        var assemblyName = new AssemblyNameDefinition("TestAssembly", new Version(1, 0, 0, 0));
+        _assembly = AssemblyDefinition.CreateAssembly(assemblyName, "TestModule", ModuleKind.Dll);
+        _module = _assembly.MainModule;
+        _type = new TypeDefinition("Test", "TestClass",
+            TypeAttributes.Class | TypeAttributes.Public,
+            _module.TypeSystem.Object);
+        _module.Types.Add(_type);
+    }
+
+    private MethodDefinition CreateMethod(string name, TypeReference returnType, params TypeReference[] paramTypes)
+    {
+        var method = new MethodDefinition(name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            returnType);
+        foreach (var paramType in paramTypes)
+        {
+            method.Parameters.Add(new ParameterDefinition(paramType));
+        }
+        _type.Methods.Add(method);
+        return method;
+    }
+
+    [Test]
+    public void TestAddZeroRight()
+    {
+        // Test: a + 0 => a
+        var method = CreateMethod("TestAddZeroRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(4, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // Should be simplified to: ldarg.0, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
+    }
+
+    [Test]
+    public void TestAddZeroLeft()
+    {
+        // Test: 0 + a => a
+        var method = CreateMethod("TestAddZeroLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(4, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // Should be simplified to: ldarg.0, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
+    }
+
+    [Test]
+    public void TestSubZero()
+    {
+        // Test: a - 0 => a
+        var method = CreateMethod("TestSubZero", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestMulOneRight()
+    {
+        // Test: a * 1 => a
+        var method = CreateMethod("TestMulOneRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestMulOneLeft()
+    {
+        // Test: 1 * a => a
+        var method = CreateMethod("TestMulOneLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestMulZeroRight()
+    {
+        // Test: a * 0 => 0 (when a is a simple load)
+        var method = CreateMethod("TestMulZeroRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestMulZeroLeft()
+    {
+        // Test: 0 * a => 0 (when a is a simple load)
+        var method = CreateMethod("TestMulZeroLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestDivOne()
+    {
+        // Test: a / 1 => a
+        var method = CreateMethod("TestDivOne", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestOrZeroRight()
+    {
+        // Test: a | 0 => a
+        var method = CreateMethod("TestOrZeroRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestOrZeroLeft()
+    {
+        // Test: 0 | a => a
+        var method = CreateMethod("TestOrZeroLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestAndAllOnesRight()
+    {
+        // Test: a & -1 => a
+        var method = CreateMethod("TestAndAllOnesRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestAndAllOnesLeft()
+    {
+        // Test: -1 & a => a
+        var method = CreateMethod("TestAndAllOnesLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestXorZeroRight()
+    {
+        // Test: a ^ 0 => a
+        var method = CreateMethod("TestXorZeroRight", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Xor);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestXorZeroLeft()
+    {
+        // Test: 0 ^ a => a
+        var method = CreateMethod("TestXorZeroLeft", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Xor);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestShiftLeftZero()
+    {
+        // Test: a << 0 => a
+        var method = CreateMethod("TestShiftLeftZero", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Shl);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestShiftRightZero()
+    {
+        // Test: a >> 0 => a
+        var method = CreateMethod("TestShiftRightZero", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Shr);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestI64AddZero()
+    {
+        // Test: a + 0L => a (i64)
+        var method = CreateMethod("TestI64AddZero", _module.TypeSystem.Int64, _module.TypeSystem.Int64);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I8, 0L);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestI64MulOne()
+    {
+        // Test: a * 1L => a (i64)
+        var method = CreateMethod("TestI64MulOne", _module.TypeSystem.Int64, _module.TypeSystem.Int64);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I8, 1L);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestF64AddZero()
+    {
+        // Test: a + 0.0 => a (f64)
+        var method = CreateMethod("TestF64AddZero", _module.TypeSystem.Double, _module.TypeSystem.Double);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestF64MulOne()
+    {
+        // Test: a * 1.0 => a (f64)
+        var method = CreateMethod("TestF64MulOne", _module.TypeSystem.Double, _module.TypeSystem.Double);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R8, 1.0);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestF32AddZero()
+    {
+        // Test: a + 0.0f => a (f32)
+        var method = CreateMethod("TestF32AddZero", _module.TypeSystem.Single, _module.TypeSystem.Single);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R4, 0.0f);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestF32MulOne()
+    {
+        // Test: a * 1.0f => a (f32)
+        var method = CreateMethod("TestF32MulOne", _module.TypeSystem.Single, _module.TypeSystem.Single);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R4, 1.0f);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestChainedSimplification()
+    {
+        // Test: (a + 0) * 1 => a
+        var method = CreateMethod("TestChained", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(6, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // Both identity operations should be removed
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestConstantFoldingThenSimplification()
+    {
+        // Test: a + (1 - 1) => a + 0 => a
+        // This tests that constant folding and algebraic simplification work together
+        var method = CreateMethod("TestCombined", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(6, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // After constant folding: a, 0, add, ret
+        // After algebraic simplification: a, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldarg_0, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestNonSimplifiableNotChanged()
+    {
+        // Test: a + 5 should not be simplified
+        var method = CreateMethod("TestNoChange", _module.TypeSystem.Int32, _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_5);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        int originalCount = method.Body.Instructions.Count;
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+    }
+}

--- a/Wasm2IL.UnitTests/TestConstantFolding.cs
+++ b/Wasm2IL.UnitTests/TestConstantFolding.cs
@@ -1,0 +1,414 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Wasm2IL.Optimization;
+
+namespace Wasm2IL.UnitTests;
+
+[TestFixture]
+public class TestConstantFolding
+{
+    private AssemblyDefinition _assembly;
+    private TypeDefinition _type;
+    private ModuleDefinition _module;
+
+    public TestConstantFolding()
+    {
+        var assemblyName = new AssemblyNameDefinition("TestAssembly", new Version(1, 0, 0, 0));
+        _assembly = AssemblyDefinition.CreateAssembly(assemblyName, "TestModule", ModuleKind.Dll);
+        _module = _assembly.MainModule;
+        _type = new TypeDefinition("Test", "TestClass",
+            TypeAttributes.Class | TypeAttributes.Public,
+            _module.TypeSystem.Object);
+        _module.Types.Add(_type);
+    }
+
+    private MethodDefinition CreateMethod(string name, TypeReference returnType)
+    {
+        var method = new MethodDefinition(name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            returnType);
+        _type.Methods.Add(method);
+        return method;
+    }
+
+    [Test]
+    public void TestI32AddFolding()
+    {
+        // Test: ldc 1, ldc 2, add => ldc 3
+        var method = CreateMethod("TestI32Add", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(4, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // Should be folded to: ldc 3, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_3, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(OpCodes.Ret, method.Body.Instructions[1].OpCode);
+    }
+
+    [Test]
+    public void TestI32SubFolding()
+    {
+        // Test: ldc 10, ldc 3, sub => ldc 7
+        var method = CreateMethod("TestI32Sub", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 10);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_7, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestI32MulFolding()
+    {
+        // Test: ldc 6, ldc 7, mul => ldc 42
+        var method = CreateMethod("TestI32Mul", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_6);
+        il.Emit(OpCodes.Ldc_I4_7);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_S, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual((sbyte)42, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestI32DivFolding()
+    {
+        // Test: ldc 100, ldc 10, div => ldc 10
+        var method = CreateMethod("TestI32Div", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 100);
+        il.Emit(OpCodes.Ldc_I4, 10);
+        il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        // 10 should use Ldc_I4_S since it's in -128..127 range
+        Assert.AreEqual(OpCodes.Ldc_I4_S, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual((sbyte)10, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestI32DivByZeroNotFolded()
+    {
+        // Division by zero should not be folded (would cause runtime behavior change)
+        var method = CreateMethod("TestI32DivByZero", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 100);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Ret);
+
+        int originalCount = method.Body.Instructions.Count;
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // Should NOT be folded
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+    }
+
+    [Test]
+    public void TestI32BitwiseAndFolding()
+    {
+        // Test: ldc 0xFF, ldc 0x0F, and => ldc 0x0F
+        var method = CreateMethod("TestI32And", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 0xFF);
+        il.Emit(OpCodes.Ldc_I4, 0x0F);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_S, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual((sbyte)0x0F, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestI32ShiftLeftFolding()
+    {
+        // Test: ldc 1, ldc 4, shl => ldc 16
+        var method = CreateMethod("TestI32Shl", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Shl);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_S, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual((sbyte)16, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestI64AddFolding()
+    {
+        // Test: ldc.i8 100, ldc.i8 200, add => ldc.i8 300
+        var method = CreateMethod("TestI64Add", _module.TypeSystem.Int64);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I8, 100L);
+        il.Emit(OpCodes.Ldc_I8, 200L);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I8, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(300L, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestF64AddFolding()
+    {
+        // Test: ldc.r8 1.5, ldc.r8 2.5, add => ldc.r8 4.0
+        var method = CreateMethod("TestF64Add", _module.TypeSystem.Double);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_R8, 1.5);
+        il.Emit(OpCodes.Ldc_R8, 2.5);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_R8, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(4.0, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestF32MulFolding()
+    {
+        // Test: ldc.r4 2.0f, ldc.r4 3.0f, mul => ldc.r4 6.0f
+        var method = CreateMethod("TestF32Mul", _module.TypeSystem.Single);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_R4, 2.0f);
+        il.Emit(OpCodes.Ldc_R4, 3.0f);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_R4, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(6.0f, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestChainedFolding()
+    {
+        // Test: ldc 1, ldc 2, add, ldc 3, mul => ldc 9
+        // (1 + 2) * 3 = 9
+        var method = CreateMethod("TestChained", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(6, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // First pass: ldc 1, ldc 2, add => ldc 3
+        // Result: ldc 3, ldc 3, mul, ret
+        // Second pass: ldc 3, ldc 3, mul => ldc 9
+        // Result: ldc 9, ret
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_S, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual((sbyte)9, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestConversionFolding()
+    {
+        // Test: ldc.i4 42, conv.i8 => ldc.i8 42
+        var method = CreateMethod("TestConv", _module.TypeSystem.Int64);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 42);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Ret);
+
+        Assert.AreEqual(3, method.Body.Instructions.Count);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I8, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(42L, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestComparisonFolding()
+    {
+        // Test: ldc 5, ldc 10, clt => ldc 1 (true)
+        var method = CreateMethod("TestClt", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4_5);
+        il.Emit(OpCodes.Ldc_I4, 10);
+        il.Emit(OpCodes.Clt);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_1, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestEqualityFolding()
+    {
+        // Test: ldc 42, ldc 42, ceq => ldc 1 (true)
+        var method = CreateMethod("TestCeq", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 42);
+        il.Emit(OpCodes.Ldc_I4, 42);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_1, method.Body.Instructions[0].OpCode);
+    }
+
+    [Test]
+    public void TestNonConstantNotFolded()
+    {
+        // Test that non-constant operations are not folded
+        var method = CreateMethod("TestNonConstant", _module.TypeSystem.Int32);
+        method.Parameters.Add(new ParameterDefinition("x", ParameterAttributes.None, _module.TypeSystem.Int32));
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        int originalCount = method.Body.Instructions.Count;
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // Should NOT be folded because first operand is not a constant
+        Assert.AreEqual(originalCount, method.Body.Instructions.Count);
+    }
+
+    [Test]
+    public void TestBranchTargetPreserved()
+    {
+        // Test that branch targets are updated when instructions are removed
+        var method = CreateMethod("TestBranch", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        // Create: if (true) return 3; else return 0;
+        // Which involves a branch to the first ldc instruction
+        var ldcInstr = il.Create(OpCodes.Ldc_I4_1);
+        var ldc2Instr = il.Create(OpCodes.Ldc_I4_2);
+
+        il.Emit(OpCodes.Br, ldcInstr);  // Jump to ldc 1
+        il.Append(ldcInstr);             // ldc 1
+        il.Append(ldc2Instr);            // ldc 2
+        il.Emit(OpCodes.Add);            // add
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        // The branch should now point to the folded ldc 3 instruction
+        Assert.AreEqual(3, method.Body.Instructions.Count);
+        var branchTarget = method.Body.Instructions[0].Operand as Instruction;
+        Assert.IsNotNull(branchTarget);
+        Assert.AreEqual(OpCodes.Ldc_I4_3, branchTarget.OpCode);
+    }
+
+    [Test]
+    public void TestNegationFolding()
+    {
+        // Test: ldc 42, neg => ldc -42
+        var method = CreateMethod("TestNeg", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 42);
+        il.Emit(OpCodes.Neg);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4_S, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual((sbyte)-42, method.Body.Instructions[0].Operand);
+    }
+
+    [Test]
+    public void TestLargeConstantFolding()
+    {
+        // Test folding that results in a value requiring Ldc_I4
+        var method = CreateMethod("TestLargeConst", _module.TypeSystem.Int32);
+        var il = method.Body.GetILProcessor();
+
+        il.Emit(OpCodes.Ldc_I4, 100000);
+        il.Emit(OpCodes.Ldc_I4, 200000);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+
+        Assert.AreEqual(2, method.Body.Instructions.Count);
+        Assert.AreEqual(OpCodes.Ldc_I4, method.Body.Instructions[0].OpCode);
+        Assert.AreEqual(300000, method.Body.Instructions[0].Operand);
+    }
+}

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -1,3 +1,4 @@
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 
 namespace Wasm2IL.Optimization;
@@ -410,15 +411,38 @@ public class AlgebraicSimplifier : IOptimizationPass
                op == OpCodes.Ldc_I8 || op == OpCodes.Ldc_R4 || op == OpCodes.Ldc_R8;
     }
 
+    /// <summary>
+    /// Check if an instruction is a "simple load" - pushes exactly 1 value and pops 0 values.
+    /// This includes: ldarg, ldloc, ldsfld, constants, and parameterless calls that return a value.
+    /// </summary>
     private static bool IsSimpleLoad(Instruction instr)
     {
         var op = instr.OpCode;
-        // Simple loads that have no side effects
-        return op == OpCodes.Ldarg_0 || op == OpCodes.Ldarg_1 || op == OpCodes.Ldarg_2 ||
-               op == OpCodes.Ldarg_3 || op == OpCodes.Ldarg_S || op == OpCodes.Ldarg ||
-               op == OpCodes.Ldloc_0 || op == OpCodes.Ldloc_1 || op == OpCodes.Ldloc_2 ||
-               op == OpCodes.Ldloc_3 || op == OpCodes.Ldloc_S || op == OpCodes.Ldloc ||
-               op == OpCodes.Ldsfld || IsConstant(instr);
+
+        // Standard loads that push 1 value and pop 0
+        if (op == OpCodes.Ldarg_0 || op == OpCodes.Ldarg_1 || op == OpCodes.Ldarg_2 ||
+            op == OpCodes.Ldarg_3 || op == OpCodes.Ldarg_S || op == OpCodes.Ldarg ||
+            op == OpCodes.Ldloc_0 || op == OpCodes.Ldloc_1 || op == OpCodes.Ldloc_2 ||
+            op == OpCodes.Ldloc_3 || op == OpCodes.Ldloc_S || op == OpCodes.Ldloc ||
+            op == OpCodes.Ldsfld)
+        {
+            return true;
+        }
+
+        // Constants are simple loads
+        if (IsConstant(instr))
+            return true;
+
+        // Calls with no parameters that return a value are also simple loads
+        // (they push 1 value and pop 0 values)
+        if (op == OpCodes.Call && instr.Operand is MethodReference method)
+        {
+            bool hasNoParams = method.Parameters.Count == 0;
+            bool returnsValue = method.ReturnType.FullName != "System.Void";
+            return hasNoParams && returnsValue;
+        }
+
+        return false;
     }
 
     private static bool TryGetI32Constant(Instruction instr, out int value)

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -194,6 +194,15 @@ public class AlgebraicSimplifier : IOptimizationPass
             RemoveConstantAndOp(body, index + 1);
             return true;
         }
+        
+        // a ^ -1 => a (all bits set)
+        if (constVal == -1 && op == OpCodes.Xor)
+        {
+            instructions.RemoveAt(index + 2);
+            instructions.RemoveAt(index + 1);
+            instructions.Insert(index + 1, il.Create(OpCodes.Not));
+            return true;
+        }
 
         // a * 0 => 0 (but need to keep side effects - only if first operand is simple)
         if (constVal == 0 && op == OpCodes.Mul && IsSimpleLoad(instructions[index]))
@@ -229,6 +238,16 @@ public class AlgebraicSimplifier : IOptimizationPass
         if (constVal == -1 && op == OpCodes.And)
         {
             RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+        
+        // -1 ^ a  => a (all bits set)
+        if (constVal == -1 && op == OpCodes.Xor)
+        {
+            var il = body.GetILProcessor();
+            instructions.RemoveAt(index + 1);
+            instructions.RemoveAt(index);
+            instructions.Insert(index + 1, il.Create(OpCodes.Not));
             return true;
         }
 
@@ -529,6 +548,7 @@ public class AlgebraicSimplifier : IOptimizationPass
         }
     }
 
+    
     /// <summary>
     /// Replace the entire expression with a constant.
     /// Used for patterns like: a * 0 => 0

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -141,14 +141,16 @@ public class AlgebraicSimplifier : IOptimizationPass
         var il = body.GetILProcessor();
         var instructions = body.Instructions;
 
-        // a + 0 => a
-        // a - 0 => a
+        // NOTE: We intentionally do NOT optimize a + 0 or a - 0 because 'add' and 'sub'
+        // are used for pointer arithmetic in IL. Without type tracking, we can't safely
+        // determine if 'a' is a pointer or integer, and removing the operation could
+        // cause type verification errors.
+
         // a | 0 => a
         // a ^ 0 => a
         // a << 0 => a
         // a >> 0 => a
-        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Sub ||
-                              op == OpCodes.Or || op == OpCodes.Xor ||
+        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor ||
                               op == OpCodes.Shl || op == OpCodes.Shr || op == OpCodes.Shr_Un))
         {
             RemoveConstantAndOp(body, index + 1);
@@ -184,10 +186,13 @@ public class AlgebraicSimplifier : IOptimizationPass
     {
         var instructions = body.Instructions;
 
-        // 0 + a => a
+        // NOTE: We intentionally do NOT optimize 0 + a because 'add' is used for
+        // pointer arithmetic in IL. Without type tracking, we can't safely determine
+        // if 'a' is a pointer or integer.
+
         // 0 | a => a
         // 0 ^ a => a
-        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Or || op == OpCodes.Xor))
+        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor))
         {
             RemoveConstantAndOp(body, index, removeFirst: true);
             return true;
@@ -225,8 +230,10 @@ public class AlgebraicSimplifier : IOptimizationPass
     {
         var instructions = body.Instructions;
 
-        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Sub ||
-                              op == OpCodes.Or || op == OpCodes.Xor ||
+        // NOTE: We do NOT optimize a + 0 or a - 0 for i64 either, for consistency
+        // with i32 and because the same pointer arithmetic concerns apply.
+
+        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor ||
                               op == OpCodes.Shl || op == OpCodes.Shr || op == OpCodes.Shr_Un))
         {
             RemoveConstantAndOp(body, index + 1);
@@ -258,7 +265,9 @@ public class AlgebraicSimplifier : IOptimizationPass
     {
         var instructions = body.Instructions;
 
-        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Or || op == OpCodes.Xor))
+        // NOTE: We do NOT optimize 0 + a for i64 for the same pointer arithmetic concerns.
+
+        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor))
         {
             RemoveConstantAndOp(body, index, removeFirst: true);
             return true;

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -166,16 +166,14 @@ public class AlgebraicSimplifier : IOptimizationPass
         var il = body.GetILProcessor();
         var instructions = body.Instructions;
 
-        // NOTE: We intentionally do NOT optimize a + 0 or a - 0 because 'add' and 'sub'
-        // are used for pointer arithmetic in IL. Without type tracking, we can't safely
-        // determine if 'a' is a pointer or integer, and removing the operation could
-        // cause type verification errors.
-
+        // a + 0 => a
+        // a - 0 => a
         // a | 0 => a
         // a ^ 0 => a
         // a << 0 => a
         // a >> 0 => a
-        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor ||
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Sub ||
+                              op == OpCodes.Or || op == OpCodes.Xor ||
                               op == OpCodes.Shl || op == OpCodes.Shr || op == OpCodes.Shr_Un))
         {
             RemoveConstantAndOp(body, index + 1);
@@ -211,13 +209,10 @@ public class AlgebraicSimplifier : IOptimizationPass
     {
         var instructions = body.Instructions;
 
-        // NOTE: We intentionally do NOT optimize 0 + a because 'add' is used for
-        // pointer arithmetic in IL. Without type tracking, we can't safely determine
-        // if 'a' is a pointer or integer.
-
+        // 0 + a => a
         // 0 | a => a
         // 0 ^ a => a
-        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor))
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Or || op == OpCodes.Xor))
         {
             RemoveConstantAndOp(body, index, removeFirst: true);
             return true;
@@ -255,10 +250,8 @@ public class AlgebraicSimplifier : IOptimizationPass
     {
         var instructions = body.Instructions;
 
-        // NOTE: We do NOT optimize a + 0 or a - 0 for i64 either, for consistency
-        // with i32 and because the same pointer arithmetic concerns apply.
-
-        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor ||
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Sub ||
+                              op == OpCodes.Or || op == OpCodes.Xor ||
                               op == OpCodes.Shl || op == OpCodes.Shr || op == OpCodes.Shr_Un))
         {
             RemoveConstantAndOp(body, index + 1);
@@ -290,9 +283,7 @@ public class AlgebraicSimplifier : IOptimizationPass
     {
         var instructions = body.Instructions;
 
-        // NOTE: We do NOT optimize 0 + a for i64 for the same pointer arithmetic concerns.
-
-        if (constVal == 0 && (op == OpCodes.Or || op == OpCodes.Xor))
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Or || op == OpCodes.Xor))
         {
             RemoveConstantAndOp(body, index, removeFirst: true);
             return true;

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -62,6 +62,13 @@ public class AlgebraicSimplifier : IOptimizationPass
         if (IsConstant(instr0))
             return false;
 
+        // IMPORTANT: The first operand must be a "simple load" - an instruction that
+        // pushes exactly 1 value and pops 0 values. Otherwise, the constant might be
+        // consumed by instr0 (e.g., as an argument to a call), and the pattern doesn't
+        // match what we think it does.
+        if (!IsSimpleLoad(instr0))
+            return false;
+
         // Check for i32 identity patterns
         if (TryGetI32Constant(instr1, out int i32val))
         {
@@ -105,6 +112,17 @@ public class AlgebraicSimplifier : IOptimizationPass
 
         // Skip if second instruction is also a constant (handled by ConstantFolder)
         if (IsConstant(instr1))
+            return false;
+
+        // IMPORTANT: The second operand must be a "simple load" - an instruction that
+        // pushes exactly 1 value and pops 0 values. Otherwise, the constant we pushed
+        // might be consumed by instr1 (e.g., as an argument to a call), and the pattern
+        // doesn't match what we think it does.
+        // Example of bad pattern:
+        //   ldc.i4.0
+        //   call SomeMethod(int)  <- consumes the 0!
+        //   add                   <- operates on different values
+        if (!IsSimpleLoad(instr1))
             return false;
 
         // Check for i32 identity patterns

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -1,0 +1,564 @@
+using Mono.Cecil.Cil;
+
+namespace Wasm2IL.Optimization;
+
+/// <summary>
+/// Algebraic simplification pass that removes identity operations.
+/// Examples:
+/// - a + 0, 0 + a => a
+/// - a - 0 => a
+/// - a * 1, 1 * a => a
+/// - a * 0, 0 * a => 0
+/// - a / 1 => a
+/// - a | 0, 0 | a => a
+/// - a &amp; -1, -1 &amp; a => a
+/// - a ^ 0, 0 ^ a => a
+/// - a &lt;&lt; 0, a &gt;&gt; 0 => a
+/// </summary>
+public class AlgebraicSimplifier : IOptimizationPass
+{
+    public bool Run(MethodBody body)
+    {
+        bool changed = false;
+        var instructions = body.Instructions;
+
+        for (int i = 0; i < instructions.Count - 1; i++)
+        {
+            // Try patterns with constant as second operand: a, const, op
+            if (i >= 1 && TrySimplifyBinaryOpWithConstantSecond(body, i - 1))
+            {
+                changed = true;
+                i = Math.Max(0, i - 2);
+                continue;
+            }
+
+            // Try patterns with constant as first operand: const, a, op
+            if (i >= 1 && TrySimplifyBinaryOpWithConstantFirst(body, i - 1))
+            {
+                changed = true;
+                i = Math.Max(0, i - 2);
+                continue;
+            }
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Try to simplify: [any], [const], [op] patterns
+    /// e.g., a + 0 => a, a * 1 => a, a * 0 => 0
+    /// </summary>
+    private bool TrySimplifyBinaryOpWithConstantSecond(MethodBody body, int index)
+    {
+        var instructions = body.Instructions;
+        if (index + 2 >= instructions.Count)
+            return false;
+
+        var instr0 = instructions[index];      // first operand (unknown)
+        var instr1 = instructions[index + 1];  // second operand (constant)
+        var instr2 = instructions[index + 2];  // operation
+
+        // Skip if first instruction is a constant (handled by ConstantFolder)
+        if (IsConstant(instr0))
+            return false;
+
+        // Check for i32 identity patterns
+        if (TryGetI32Constant(instr1, out int i32val))
+        {
+            return TrySimplifyI32WithConstantSecond(body, index, i32val, instr2.OpCode);
+        }
+
+        // Check for i64 identity patterns
+        if (TryGetI64Constant(instr1, out long i64val))
+        {
+            return TrySimplifyI64WithConstantSecond(body, index, i64val, instr2.OpCode);
+        }
+
+        // Check for f32 identity patterns
+        if (TryGetF32Constant(instr1, out float f32val))
+        {
+            return TrySimplifyF32WithConstantSecond(body, index, f32val, instr2.OpCode);
+        }
+
+        // Check for f64 identity patterns
+        if (TryGetF64Constant(instr1, out double f64val))
+        {
+            return TrySimplifyF64WithConstantSecond(body, index, f64val, instr2.OpCode);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to simplify: [const], [any], [op] patterns
+    /// e.g., 0 + a => a, 1 * a => a, 0 * a => 0
+    /// </summary>
+    private bool TrySimplifyBinaryOpWithConstantFirst(MethodBody body, int index)
+    {
+        var instructions = body.Instructions;
+        if (index + 2 >= instructions.Count)
+            return false;
+
+        var instr0 = instructions[index];      // first operand (constant)
+        var instr1 = instructions[index + 1];  // second operand (unknown)
+        var instr2 = instructions[index + 2];  // operation
+
+        // Skip if second instruction is also a constant (handled by ConstantFolder)
+        if (IsConstant(instr1))
+            return false;
+
+        // Check for i32 identity patterns
+        if (TryGetI32Constant(instr0, out int i32val))
+        {
+            return TrySimplifyI32WithConstantFirst(body, index, i32val, instr2.OpCode);
+        }
+
+        // Check for i64 identity patterns
+        if (TryGetI64Constant(instr0, out long i64val))
+        {
+            return TrySimplifyI64WithConstantFirst(body, index, i64val, instr2.OpCode);
+        }
+
+        // Check for f32 identity patterns
+        if (TryGetF32Constant(instr0, out float f32val))
+        {
+            return TrySimplifyF32WithConstantFirst(body, index, f32val, instr2.OpCode);
+        }
+
+        // Check for f64 identity patterns
+        if (TryGetF64Constant(instr0, out double f64val))
+        {
+            return TrySimplifyF64WithConstantFirst(body, index, f64val, instr2.OpCode);
+        }
+
+        return false;
+    }
+
+    #region I32 Simplification
+
+    private bool TrySimplifyI32WithConstantSecond(MethodBody body, int index, int constVal, OpCode op)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+
+        // a + 0 => a
+        // a - 0 => a
+        // a | 0 => a
+        // a ^ 0 => a
+        // a << 0 => a
+        // a >> 0 => a
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Sub ||
+                              op == OpCodes.Or || op == OpCodes.Xor ||
+                              op == OpCodes.Shl || op == OpCodes.Shr || op == OpCodes.Shr_Un))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        // a * 1 => a
+        // a / 1 => a
+        if (constVal == 1 && (op == OpCodes.Mul || op == OpCodes.Div || op == OpCodes.Div_Un))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        // a & -1 => a (all bits set)
+        if (constVal == -1 && op == OpCodes.And)
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        // a * 0 => 0 (but need to keep side effects - only if first operand is simple)
+        if (constVal == 0 && op == OpCodes.Mul && IsSimpleLoad(instructions[index]))
+        {
+            ReplaceWithConstant(body, index, 0);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TrySimplifyI32WithConstantFirst(MethodBody body, int index, int constVal, OpCode op)
+    {
+        var instructions = body.Instructions;
+
+        // 0 + a => a
+        // 0 | a => a
+        // 0 ^ a => a
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Or || op == OpCodes.Xor))
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        // 1 * a => a
+        if (constVal == 1 && op == OpCodes.Mul)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        // -1 & a => a
+        if (constVal == -1 && op == OpCodes.And)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        // 0 * a => 0 (but need to keep side effects - only if second operand is simple)
+        if (constVal == 0 && op == OpCodes.Mul && IsSimpleLoad(instructions[index + 1]))
+        {
+            ReplaceWithConstant(body, index, 0, removeSecondOperand: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    #region I64 Simplification
+
+    private bool TrySimplifyI64WithConstantSecond(MethodBody body, int index, long constVal, OpCode op)
+    {
+        var instructions = body.Instructions;
+
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Sub ||
+                              op == OpCodes.Or || op == OpCodes.Xor ||
+                              op == OpCodes.Shl || op == OpCodes.Shr || op == OpCodes.Shr_Un))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        if (constVal == 1 && (op == OpCodes.Mul || op == OpCodes.Div || op == OpCodes.Div_Un))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        if (constVal == -1 && op == OpCodes.And)
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        if (constVal == 0 && op == OpCodes.Mul && IsSimpleLoad(instructions[index]))
+        {
+            ReplaceWithI64Constant(body, index, 0);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TrySimplifyI64WithConstantFirst(MethodBody body, int index, long constVal, OpCode op)
+    {
+        var instructions = body.Instructions;
+
+        if (constVal == 0 && (op == OpCodes.Add || op == OpCodes.Or || op == OpCodes.Xor))
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        if (constVal == 1 && op == OpCodes.Mul)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        if (constVal == -1 && op == OpCodes.And)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        if (constVal == 0 && op == OpCodes.Mul && IsSimpleLoad(instructions[index + 1]))
+        {
+            ReplaceWithI64Constant(body, index, 0, removeSecondOperand: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    #region F32 Simplification
+
+    private bool TrySimplifyF32WithConstantSecond(MethodBody body, int index, float constVal, OpCode op)
+    {
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 0.0f && (op == OpCodes.Add || op == OpCodes.Sub))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 1.0f && (op == OpCodes.Mul || op == OpCodes.Div))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TrySimplifyF32WithConstantFirst(MethodBody body, int index, float constVal, OpCode op)
+    {
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 0.0f && op == OpCodes.Add)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 1.0f && op == OpCodes.Mul)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    #region F64 Simplification
+
+    private bool TrySimplifyF64WithConstantSecond(MethodBody body, int index, double constVal, OpCode op)
+    {
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 0.0 && (op == OpCodes.Add || op == OpCodes.Sub))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 1.0 && (op == OpCodes.Mul || op == OpCodes.Div))
+        {
+            RemoveConstantAndOp(body, index + 1);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TrySimplifyF64WithConstantFirst(MethodBody body, int index, double constVal, OpCode op)
+    {
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 0.0 && op == OpCodes.Add)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        // ReSharper disable once CompareOfFloatsByEqualityOperator
+        if (constVal == 1.0 && op == OpCodes.Mul)
+        {
+            RemoveConstantAndOp(body, index, removeFirst: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static bool IsConstant(Instruction instr)
+    {
+        var op = instr.OpCode;
+        return op == OpCodes.Ldc_I4_M1 || op == OpCodes.Ldc_I4_0 || op == OpCodes.Ldc_I4_1 ||
+               op == OpCodes.Ldc_I4_2 || op == OpCodes.Ldc_I4_3 || op == OpCodes.Ldc_I4_4 ||
+               op == OpCodes.Ldc_I4_5 || op == OpCodes.Ldc_I4_6 || op == OpCodes.Ldc_I4_7 ||
+               op == OpCodes.Ldc_I4_8 || op == OpCodes.Ldc_I4_S || op == OpCodes.Ldc_I4 ||
+               op == OpCodes.Ldc_I8 || op == OpCodes.Ldc_R4 || op == OpCodes.Ldc_R8;
+    }
+
+    private static bool IsSimpleLoad(Instruction instr)
+    {
+        var op = instr.OpCode;
+        // Simple loads that have no side effects
+        return op == OpCodes.Ldarg_0 || op == OpCodes.Ldarg_1 || op == OpCodes.Ldarg_2 ||
+               op == OpCodes.Ldarg_3 || op == OpCodes.Ldarg_S || op == OpCodes.Ldarg ||
+               op == OpCodes.Ldloc_0 || op == OpCodes.Ldloc_1 || op == OpCodes.Ldloc_2 ||
+               op == OpCodes.Ldloc_3 || op == OpCodes.Ldloc_S || op == OpCodes.Ldloc ||
+               op == OpCodes.Ldsfld || IsConstant(instr);
+    }
+
+    private static bool TryGetI32Constant(Instruction instr, out int value)
+    {
+        value = 0;
+        var opCode = instr.OpCode;
+
+        if (opCode == OpCodes.Ldc_I4_M1) { value = -1; return true; }
+        if (opCode == OpCodes.Ldc_I4_0) { value = 0; return true; }
+        if (opCode == OpCodes.Ldc_I4_1) { value = 1; return true; }
+        if (opCode == OpCodes.Ldc_I4_2) { value = 2; return true; }
+        if (opCode == OpCodes.Ldc_I4_3) { value = 3; return true; }
+        if (opCode == OpCodes.Ldc_I4_4) { value = 4; return true; }
+        if (opCode == OpCodes.Ldc_I4_5) { value = 5; return true; }
+        if (opCode == OpCodes.Ldc_I4_6) { value = 6; return true; }
+        if (opCode == OpCodes.Ldc_I4_7) { value = 7; return true; }
+        if (opCode == OpCodes.Ldc_I4_8) { value = 8; return true; }
+        if (opCode == OpCodes.Ldc_I4_S) { value = (sbyte)instr.Operand; return true; }
+        if (opCode == OpCodes.Ldc_I4) { value = (int)instr.Operand; return true; }
+
+        return false;
+    }
+
+    private static bool TryGetI64Constant(Instruction instr, out long value)
+    {
+        value = 0;
+        if (instr.OpCode == OpCodes.Ldc_I8)
+        {
+            value = (long)instr.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryGetF32Constant(Instruction instr, out float value)
+    {
+        value = 0;
+        if (instr.OpCode == OpCodes.Ldc_R4)
+        {
+            value = (float)instr.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryGetF64Constant(Instruction instr, out double value)
+    {
+        value = 0;
+        if (instr.OpCode == OpCodes.Ldc_R8)
+        {
+            value = (double)instr.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Remove constant at index and the operation at index+1
+    /// Used for patterns like: a, 0, add => a
+    /// </summary>
+    private void RemoveConstantAndOp(MethodBody body, int constIndex, bool removeFirst = false)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+
+        if (removeFirst)
+        {
+            // Pattern: const, a, op => a
+            // Remove const (index) and op (index+2, becomes index+1 after first removal)
+            var constInstr = instructions[constIndex];
+            var opInstr = instructions[constIndex + 2];
+
+            // Redirect branches from const to a
+            RedirectBranches(body, constInstr, instructions[constIndex + 1]);
+            il.Remove(constInstr);
+            il.Remove(opInstr); // now at constIndex + 1
+        }
+        else
+        {
+            // Pattern: a, const, op => a
+            // Remove const (constIndex) and op (constIndex+1)
+            var constInstr = instructions[constIndex];
+            var opInstr = instructions[constIndex + 1];
+
+            il.Remove(constInstr);
+            il.Remove(opInstr); // now at constIndex
+        }
+    }
+
+    /// <summary>
+    /// Replace the entire expression with a constant.
+    /// Used for patterns like: a * 0 => 0
+    /// </summary>
+    private void ReplaceWithConstant(MethodBody body, int index, int value, bool removeSecondOperand = false)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+
+        var firstInstr = instructions[index];
+        var newInstr = CreateLdcI4(il, value);
+
+        RedirectBranches(body, firstInstr, newInstr);
+        il.Replace(firstInstr, newInstr);
+        il.Remove(instructions[index + 1]); // second operand or const
+        il.Remove(instructions[index + 1]); // op
+    }
+
+    private void ReplaceWithI64Constant(MethodBody body, int index, long value, bool removeSecondOperand = false)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+
+        var firstInstr = instructions[index];
+        var newInstr = il.Create(OpCodes.Ldc_I8, value);
+
+        RedirectBranches(body, firstInstr, newInstr);
+        il.Replace(firstInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private static Instruction CreateLdcI4(ILProcessor il, int value)
+    {
+        return value switch
+        {
+            -1 => il.Create(OpCodes.Ldc_I4_M1),
+            0 => il.Create(OpCodes.Ldc_I4_0),
+            1 => il.Create(OpCodes.Ldc_I4_1),
+            2 => il.Create(OpCodes.Ldc_I4_2),
+            3 => il.Create(OpCodes.Ldc_I4_3),
+            4 => il.Create(OpCodes.Ldc_I4_4),
+            5 => il.Create(OpCodes.Ldc_I4_5),
+            6 => il.Create(OpCodes.Ldc_I4_6),
+            7 => il.Create(OpCodes.Ldc_I4_7),
+            8 => il.Create(OpCodes.Ldc_I4_8),
+            >= -128 and <= 127 => il.Create(OpCodes.Ldc_I4_S, (sbyte)value),
+            _ => il.Create(OpCodes.Ldc_I4, value)
+        };
+    }
+
+    private static void RedirectBranches(MethodBody body, Instruction oldTarget, Instruction newTarget)
+    {
+        foreach (var instr in body.Instructions)
+        {
+            if (instr.Operand == oldTarget)
+            {
+                instr.Operand = newTarget;
+            }
+            else if (instr.Operand is Instruction[] targets)
+            {
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    if (targets[i] == oldTarget)
+                        targets[i] = newTarget;
+                }
+            }
+        }
+
+        foreach (var handler in body.ExceptionHandlers)
+        {
+            if (handler.TryStart == oldTarget) handler.TryStart = newTarget;
+            if (handler.TryEnd == oldTarget) handler.TryEnd = newTarget;
+            if (handler.HandlerStart == oldTarget) handler.HandlerStart = newTarget;
+            if (handler.HandlerEnd == oldTarget) handler.HandlerEnd = newTarget;
+            if (handler.FilterStart == oldTarget) handler.FilterStart = newTarget;
+        }
+    }
+
+    #endregion
+}

--- a/Wasm2IL/Optimization/AlgebraicSimplifier.cs
+++ b/Wasm2IL/Optimization/AlgebraicSimplifier.cs
@@ -63,12 +63,18 @@ public class AlgebraicSimplifier : IOptimizationPass
         if (IsConstant(instr0))
             return false;
 
-        // IMPORTANT: The first operand must be a "simple load" - an instruction that
-        // pushes exactly 1 value and pops 0 values. Otherwise, the constant might be
-        // consumed by instr0 (e.g., as an argument to a call), and the pattern doesn't
-        // match what we think it does.
-        if (!IsSimpleLoad(instr0))
-            return false;
+        // NOTE: We do NOT need to check if instr0 is a simple load here.
+        // Since const (instr1) is directly before op (instr2), the constant
+        // is definitely consumed by the op - it cannot be consumed by instr0
+        // because instr0 executes BEFORE the constant is pushed.
+        //
+        // Example that works:
+        //   call SomeMethod()  ; pushes result
+        //   ldc.i4.1           ; pushes 1
+        //   mul                ; result * 1 => result
+        //
+        // The call can be anything - it doesn't matter because the constant
+        // is adjacent to the mul, so the mul definitely consumes the 1.
 
         // Check for i32 identity patterns
         if (TryGetI32Constant(instr1, out int i32val))

--- a/Wasm2IL/Optimization/ConstantFolder.cs
+++ b/Wasm2IL/Optimization/ConstantFolder.cs
@@ -1,0 +1,521 @@
+using Mono.Cecil.Cil;
+
+namespace Wasm2IL.Optimization;
+
+/// <summary>
+/// Constant folding optimization pass.
+/// Folds sequences like: ldc X, ldc Y, add => ldc (X+Y)
+/// </summary>
+public class ConstantFolder : IOptimizationPass
+{
+    public bool Run(MethodBody body)
+    {
+        bool changed = false;
+        var instructions = body.Instructions;
+
+        // Keep scanning until no more changes
+        for (int i = 0; i < instructions.Count - 2; i++)
+        {
+            // Try to fold binary operations on two constants
+            if (TryFoldBinaryOp(body, i))
+            {
+                changed = true;
+                // Restart from current position since we removed instructions
+                i = Math.Max(0, i - 1);
+                continue;
+            }
+
+            // Try to fold unary operations on a constant
+            if (TryFoldUnaryOp(body, i))
+            {
+                changed = true;
+                i = Math.Max(0, i - 1);
+                continue;
+            }
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Try to fold a binary operation: ldc A, ldc B, op => ldc result
+    /// </summary>
+    private bool TryFoldBinaryOp(MethodBody body, int index)
+    {
+        var instructions = body.Instructions;
+        if (index + 2 >= instructions.Count)
+            return false;
+
+        var instr0 = instructions[index];
+        var instr1 = instructions[index + 1];
+        var instr2 = instructions[index + 2];
+
+        // Check for i32 binary operations
+        if (TryGetI32Constant(instr0, out int a) &&
+            TryGetI32Constant(instr1, out int b))
+        {
+            int? result = EvaluateI32BinaryOp(instr2.OpCode, a, b);
+            if (result.HasValue)
+            {
+                ReplaceBinaryWithConstant(body, index, result.Value);
+                return true;
+            }
+        }
+
+        // Check for i64 binary operations
+        if (TryGetI64Constant(instr0, out long la) &&
+            TryGetI64Constant(instr1, out long lb))
+        {
+            long? result = EvaluateI64BinaryOp(instr2.OpCode, la, lb);
+            if (result.HasValue)
+            {
+                ReplaceBinaryWithI64Constant(body, index, result.Value);
+                return true;
+            }
+        }
+
+        // Check for f32 binary operations
+        if (TryGetF32Constant(instr0, out float fa) &&
+            TryGetF32Constant(instr1, out float fb))
+        {
+            float? result = EvaluateF32BinaryOp(instr2.OpCode, fa, fb);
+            if (result.HasValue)
+            {
+                ReplaceBinaryWithF32Constant(body, index, result.Value);
+                return true;
+            }
+        }
+
+        // Check for f64 binary operations
+        if (TryGetF64Constant(instr0, out double da) &&
+            TryGetF64Constant(instr1, out double db))
+        {
+            double? result = EvaluateF64BinaryOp(instr2.OpCode, da, db);
+            if (result.HasValue)
+            {
+                ReplaceBinaryWithF64Constant(body, index, result.Value);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to fold a unary operation: ldc A, op => ldc result
+    /// </summary>
+    private bool TryFoldUnaryOp(MethodBody body, int index)
+    {
+        var instructions = body.Instructions;
+        if (index + 1 >= instructions.Count)
+            return false;
+
+        var instr0 = instructions[index];
+        var instr1 = instructions[index + 1];
+
+        // i32 unary operations
+        if (TryGetI32Constant(instr0, out int a))
+        {
+            int? result = EvaluateI32UnaryOp(instr1.OpCode, a);
+            if (result.HasValue)
+            {
+                ReplaceUnaryWithConstant(body, index, result.Value);
+                return true;
+            }
+
+            // i32 to i64 conversion
+            if (instr1.OpCode == OpCodes.Conv_I8)
+            {
+                ReplaceUnaryWithI64Constant(body, index, (long)a);
+                return true;
+            }
+            if (instr1.OpCode == OpCodes.Conv_U8)
+            {
+                ReplaceUnaryWithI64Constant(body, index, (long)(uint)a);
+                return true;
+            }
+            // i32 to f32/f64 conversion
+            if (instr1.OpCode == OpCodes.Conv_R4)
+            {
+                ReplaceUnaryWithF32Constant(body, index, (float)a);
+                return true;
+            }
+            if (instr1.OpCode == OpCodes.Conv_R8)
+            {
+                ReplaceUnaryWithF64Constant(body, index, (double)a);
+                return true;
+            }
+        }
+
+        // i64 unary operations
+        if (TryGetI64Constant(instr0, out long la))
+        {
+            long? result = EvaluateI64UnaryOp(instr1.OpCode, la);
+            if (result.HasValue)
+            {
+                ReplaceUnaryWithI64Constant(body, index, result.Value);
+                return true;
+            }
+
+            // i64 to i32 conversion
+            if (instr1.OpCode == OpCodes.Conv_I4)
+            {
+                ReplaceUnaryWithConstant(body, index, (int)la);
+                return true;
+            }
+            if (instr1.OpCode == OpCodes.Conv_U4)
+            {
+                ReplaceUnaryWithConstant(body, index, (int)(uint)la);
+                return true;
+            }
+            // i64 to f32/f64 conversion
+            if (instr1.OpCode == OpCodes.Conv_R4)
+            {
+                ReplaceUnaryWithF32Constant(body, index, (float)la);
+                return true;
+            }
+            if (instr1.OpCode == OpCodes.Conv_R8)
+            {
+                ReplaceUnaryWithF64Constant(body, index, (double)la);
+                return true;
+            }
+        }
+
+        // f64 unary operations
+        if (TryGetF64Constant(instr0, out double da))
+        {
+            double? result = EvaluateF64UnaryOp(instr1.OpCode, da);
+            if (result.HasValue)
+            {
+                ReplaceUnaryWithF64Constant(body, index, result.Value);
+                return true;
+            }
+        }
+
+        // f32 unary operations
+        if (TryGetF32Constant(instr0, out float fa))
+        {
+            float? result = EvaluateF32UnaryOp(instr1.OpCode, fa);
+            if (result.HasValue)
+            {
+                ReplaceUnaryWithF32Constant(body, index, result.Value);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    #region Constant Extraction
+
+    private static bool TryGetI32Constant(Instruction instr, out int value)
+    {
+        value = 0;
+        var opCode = instr.OpCode;
+
+        if (opCode == OpCodes.Ldc_I4_M1) { value = -1; return true; }
+        if (opCode == OpCodes.Ldc_I4_0) { value = 0; return true; }
+        if (opCode == OpCodes.Ldc_I4_1) { value = 1; return true; }
+        if (opCode == OpCodes.Ldc_I4_2) { value = 2; return true; }
+        if (opCode == OpCodes.Ldc_I4_3) { value = 3; return true; }
+        if (opCode == OpCodes.Ldc_I4_4) { value = 4; return true; }
+        if (opCode == OpCodes.Ldc_I4_5) { value = 5; return true; }
+        if (opCode == OpCodes.Ldc_I4_6) { value = 6; return true; }
+        if (opCode == OpCodes.Ldc_I4_7) { value = 7; return true; }
+        if (opCode == OpCodes.Ldc_I4_8) { value = 8; return true; }
+        if (opCode == OpCodes.Ldc_I4_S) { value = (sbyte)instr.Operand; return true; }
+        if (opCode == OpCodes.Ldc_I4) { value = (int)instr.Operand; return true; }
+
+        return false;
+    }
+
+    private static bool TryGetI64Constant(Instruction instr, out long value)
+    {
+        value = 0;
+        if (instr.OpCode == OpCodes.Ldc_I8)
+        {
+            value = (long)instr.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryGetF32Constant(Instruction instr, out float value)
+    {
+        value = 0;
+        if (instr.OpCode == OpCodes.Ldc_R4)
+        {
+            value = (float)instr.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool TryGetF64Constant(Instruction instr, out double value)
+    {
+        value = 0;
+        if (instr.OpCode == OpCodes.Ldc_R8)
+        {
+            value = (double)instr.Operand;
+            return true;
+        }
+        return false;
+    }
+
+    #endregion
+
+    #region Binary Operation Evaluation
+
+    private static int? EvaluateI32BinaryOp(OpCode opCode, int a, int b)
+    {
+        if (opCode == OpCodes.Add) return a + b;
+        if (opCode == OpCodes.Sub) return a - b;
+        if (opCode == OpCodes.Mul) return a * b;
+        if (opCode == OpCodes.Div && b != 0) return a / b;
+        if (opCode == OpCodes.Div_Un && b != 0) return (int)((uint)a / (uint)b);
+        if (opCode == OpCodes.Rem && b != 0) return a % b;
+        if (opCode == OpCodes.Rem_Un && b != 0) return (int)((uint)a % (uint)b);
+        if (opCode == OpCodes.And) return a & b;
+        if (opCode == OpCodes.Or) return a | b;
+        if (opCode == OpCodes.Xor) return a ^ b;
+        if (opCode == OpCodes.Shl) return a << (b & 0x1F);
+        if (opCode == OpCodes.Shr) return a >> (b & 0x1F);
+        if (opCode == OpCodes.Shr_Un) return (int)((uint)a >> (b & 0x1F));
+        if (opCode == OpCodes.Ceq) return a == b ? 1 : 0;
+        if (opCode == OpCodes.Clt) return a < b ? 1 : 0;
+        if (opCode == OpCodes.Clt_Un) return (uint)a < (uint)b ? 1 : 0;
+        if (opCode == OpCodes.Cgt) return a > b ? 1 : 0;
+        if (opCode == OpCodes.Cgt_Un) return (uint)a > (uint)b ? 1 : 0;
+        return null;
+    }
+
+    private static long? EvaluateI64BinaryOp(OpCode opCode, long a, long b)
+    {
+        if (opCode == OpCodes.Add) return a + b;
+        if (opCode == OpCodes.Sub) return a - b;
+        if (opCode == OpCodes.Mul) return a * b;
+        if (opCode == OpCodes.Div && b != 0) return a / b;
+        if (opCode == OpCodes.Div_Un && b != 0) return (long)((ulong)a / (ulong)b);
+        if (opCode == OpCodes.Rem && b != 0) return a % b;
+        if (opCode == OpCodes.Rem_Un && b != 0) return (long)((ulong)a % (ulong)b);
+        if (opCode == OpCodes.And) return a & b;
+        if (opCode == OpCodes.Or) return a | b;
+        if (opCode == OpCodes.Xor) return a ^ b;
+        if (opCode == OpCodes.Shl) return a << (int)(b & 0x3F);
+        if (opCode == OpCodes.Shr) return a >> (int)(b & 0x3F);
+        if (opCode == OpCodes.Shr_Un) return (long)((ulong)a >> (int)(b & 0x3F));
+        return null;
+    }
+
+    private static float? EvaluateF32BinaryOp(OpCode opCode, float a, float b)
+    {
+        if (opCode == OpCodes.Add) return a + b;
+        if (opCode == OpCodes.Sub) return a - b;
+        if (opCode == OpCodes.Mul) return a * b;
+        if (opCode == OpCodes.Div) return a / b;
+        return null;
+    }
+
+    private static double? EvaluateF64BinaryOp(OpCode opCode, double a, double b)
+    {
+        if (opCode == OpCodes.Add) return a + b;
+        if (opCode == OpCodes.Sub) return a - b;
+        if (opCode == OpCodes.Mul) return a * b;
+        if (opCode == OpCodes.Div) return a / b;
+        return null;
+    }
+
+    #endregion
+
+    #region Unary Operation Evaluation
+
+    private static int? EvaluateI32UnaryOp(OpCode opCode, int a)
+    {
+        if (opCode == OpCodes.Neg) return -a;
+        if (opCode == OpCodes.Not) return ~a;
+        return null;
+    }
+
+    private static long? EvaluateI64UnaryOp(OpCode opCode, long a)
+    {
+        if (opCode == OpCodes.Neg) return -a;
+        if (opCode == OpCodes.Not) return ~a;
+        return null;
+    }
+
+    private static float? EvaluateF32UnaryOp(OpCode opCode, float a)
+    {
+        if (opCode == OpCodes.Neg) return -a;
+        return null;
+    }
+
+    private static double? EvaluateF64UnaryOp(OpCode opCode, double a)
+    {
+        if (opCode == OpCodes.Neg) return -a;
+        return null;
+    }
+
+    #endregion
+
+    #region Instruction Replacement
+
+    private void ReplaceBinaryWithConstant(MethodBody body, int index, int value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+
+        // Get the target instruction (the first ldc) for branch retargeting
+        var targetInstr = instructions[index];
+
+        // Create the new constant instruction
+        var newInstr = CreateLdcI4(il, value);
+
+        // Replace the first instruction with the new constant
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+
+        // Remove the second ldc and the operation
+        il.Remove(instructions[index + 1]); // was instr1
+        il.Remove(instructions[index + 1]); // was instr2 (now at index+1)
+    }
+
+    private void ReplaceBinaryWithI64Constant(MethodBody body, int index, long value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = il.Create(OpCodes.Ldc_I8, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private void ReplaceBinaryWithF32Constant(MethodBody body, int index, float value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = il.Create(OpCodes.Ldc_R4, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private void ReplaceBinaryWithF64Constant(MethodBody body, int index, double value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = il.Create(OpCodes.Ldc_R8, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private void ReplaceUnaryWithConstant(MethodBody body, int index, int value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = CreateLdcI4(il, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private void ReplaceUnaryWithI64Constant(MethodBody body, int index, long value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = il.Create(OpCodes.Ldc_I8, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private void ReplaceUnaryWithF32Constant(MethodBody body, int index, float value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = il.Create(OpCodes.Ldc_R4, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private void ReplaceUnaryWithF64Constant(MethodBody body, int index, double value)
+    {
+        var il = body.GetILProcessor();
+        var instructions = body.Instructions;
+        var targetInstr = instructions[index];
+
+        var newInstr = il.Create(OpCodes.Ldc_R8, value);
+        RedirectBranches(body, targetInstr, newInstr);
+        il.Replace(targetInstr, newInstr);
+        il.Remove(instructions[index + 1]);
+    }
+
+    private static Instruction CreateLdcI4(ILProcessor il, int value)
+    {
+        return value switch
+        {
+            -1 => il.Create(OpCodes.Ldc_I4_M1),
+            0 => il.Create(OpCodes.Ldc_I4_0),
+            1 => il.Create(OpCodes.Ldc_I4_1),
+            2 => il.Create(OpCodes.Ldc_I4_2),
+            3 => il.Create(OpCodes.Ldc_I4_3),
+            4 => il.Create(OpCodes.Ldc_I4_4),
+            5 => il.Create(OpCodes.Ldc_I4_5),
+            6 => il.Create(OpCodes.Ldc_I4_6),
+            7 => il.Create(OpCodes.Ldc_I4_7),
+            8 => il.Create(OpCodes.Ldc_I4_8),
+            >= -128 and <= 127 => il.Create(OpCodes.Ldc_I4_S, (sbyte)value),
+            _ => il.Create(OpCodes.Ldc_I4, value)
+        };
+    }
+
+    /// <summary>
+    /// Redirect all branches pointing to oldTarget to point to newTarget.
+    /// </summary>
+    private static void RedirectBranches(MethodBody body, Instruction oldTarget, Instruction newTarget)
+    {
+        foreach (var instr in body.Instructions)
+        {
+            if (instr.Operand == oldTarget)
+            {
+                instr.Operand = newTarget;
+            }
+            else if (instr.Operand is Instruction[] targets)
+            {
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    if (targets[i] == oldTarget)
+                        targets[i] = newTarget;
+                }
+            }
+        }
+
+        // Also update exception handlers
+        foreach (var handler in body.ExceptionHandlers)
+        {
+            if (handler.TryStart == oldTarget) handler.TryStart = newTarget;
+            if (handler.TryEnd == oldTarget) handler.TryEnd = newTarget;
+            if (handler.HandlerStart == oldTarget) handler.HandlerStart = newTarget;
+            if (handler.HandlerEnd == oldTarget) handler.HandlerEnd = newTarget;
+            if (handler.FilterStart == oldTarget) handler.FilterStart = newTarget;
+        }
+    }
+
+    #endregion
+}

--- a/Wasm2IL/Optimization/ILOptimizer.cs
+++ b/Wasm2IL/Optimization/ILOptimizer.cs
@@ -18,6 +18,7 @@ public class ILOptimizer
 
         // Register default optimization passes
         _passes.Add(new ConstantFolder());
+        _passes.Add(new AlgebraicSimplifier());
     }
 
     /// <summary>

--- a/Wasm2IL/Optimization/ILOptimizer.cs
+++ b/Wasm2IL/Optimization/ILOptimizer.cs
@@ -1,0 +1,85 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Wasm2IL.Optimization;
+
+/// <summary>
+/// Orchestrates IL optimization passes on generated methods.
+/// Runs passes in a fixed-point loop until no more changes occur.
+/// </summary>
+public class ILOptimizer
+{
+    private readonly MethodBody _body;
+    private readonly List<IOptimizationPass> _passes = new();
+
+    public ILOptimizer(MethodBody body)
+    {
+        _body = body;
+
+        // Register default optimization passes
+        _passes.Add(new ConstantFolder());
+    }
+
+    /// <summary>
+    /// Add a custom optimization pass.
+    /// </summary>
+    public void AddPass(IOptimizationPass pass)
+    {
+        _passes.Add(pass);
+    }
+
+    /// <summary>
+    /// Run all optimization passes until a fixed point is reached.
+    /// </summary>
+    public void Optimize()
+    {
+        bool changed;
+        int iterations = 0;
+        const int maxIterations = 100; // Safety limit
+
+        do
+        {
+            changed = false;
+            foreach (var pass in _passes)
+            {
+                changed |= pass.Run(_body);
+            }
+            iterations++;
+        } while (changed && iterations < maxIterations);
+    }
+
+    /// <summary>
+    /// Optimize a single method.
+    /// </summary>
+    public static void OptimizeMethod(MethodDefinition method)
+    {
+        if (method.Body == null || method.Body.Instructions.Count == 0)
+            return;
+
+        var optimizer = new ILOptimizer(method.Body);
+        optimizer.Optimize();
+    }
+
+    /// <summary>
+    /// Optimize all methods in a type.
+    /// </summary>
+    public static void OptimizeType(TypeDefinition type)
+    {
+        foreach (var method in type.Methods)
+        {
+            OptimizeMethod(method);
+        }
+    }
+}
+
+/// <summary>
+/// Interface for optimization passes.
+/// </summary>
+public interface IOptimizationPass
+{
+    /// <summary>
+    /// Run the optimization pass on the method body.
+    /// </summary>
+    /// <returns>True if any changes were made.</returns>
+    bool Run(MethodBody body);
+}

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1631,12 +1631,38 @@ namespace Wasm2IL
                         case instr.I64_LE_U:
                         case instr.F64_LE:
                         case instr.F32_LE:
+                            
                             // invert the logic
                             var unsigned = instr.ToString().Contains("_U");
                             var le = instr.ToString().Contains("LE");
+                            
+                            if ((instr) reader.Clone().ReadU8() == instr.BR_IF)
+                            {
+                                instr = (instr) reader.ReadU8();
+                                pop();
+                                if (unsigned)
+                                {
+                                    if (le)
+                                        jmpInstr = IlInstr.Ble_Un;
+                                    else
+                                        jmpInstr = IlInstr.Bge_Un;
+                                }
+                                else
+                                {
+                                    if (le)
+                                        jmpInstr = IlInstr.Ble;
+                                    else
+                                        jmpInstr = IlInstr.Bge;
+                                }
+                                
+                                goto case instr.BR_IF;
+                            }
+                            
                             OpCode cmp = le ? (unsigned ? IlInstr.Cgt_Un : IlInstr.Cgt) 
                                 : (unsigned ? IlInstr.Clt_Un : IlInstr.Clt);
 
+                            
+                            
                             il.Emit(cmp);
                             il.Emit(IlInstr.Ldc_I4_0);
                             il.Emit(IlInstr.Ceq);

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -11,6 +11,7 @@ using Mono.Cecil.Rocks;
 using Wasm;
 using Wasm2CIl.Utils;
 using Wasm2IL.Dwarf;
+using Wasm2IL.Optimization;
 using AssemblyDefinition = Mono.Cecil.AssemblyDefinition;
 using FieldAttributes = Mono.Cecil.FieldAttributes;
 using FieldDefinition = Mono.Cecil.FieldDefinition;
@@ -42,6 +43,11 @@ namespace Wasm2IL
     {
         readonly Dictionary<string, List<Type>> importModules = new();
         private List<Type> overrideModules = [];
+
+        /// <summary>
+        /// Enable IL optimizations like constant folding. Default is true.
+        /// </summary>
+        public bool EnableOptimizations { get; set; } = true;
 
         public void LoadImportModule(string moduleName, Type type)
         {
@@ -350,6 +356,13 @@ namespace Wasm2IL
 
             reader.Position = codeLoc;
             ReadCodeSection(reader);
+
+            // Run IL optimizations if enabled
+            if (EnableOptimizations)
+            {
+                ILOptimizer.OptimizeType(cls);
+            }
+
             def.Write(outStream);
 
 

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -361,6 +361,10 @@ namespace Wasm2IL
             if (EnableOptimizations)
             {
                 ILOptimizer.OptimizeType(cls);
+                foreach (var method in cls.Methods)
+                {
+                    method.Body.Optimize();
+                }
             }
 
             def.Write(outStream);
@@ -2260,10 +2264,7 @@ namespace Wasm2IL
                 next: ;
             }
 
-            foreach (var method in cls.Methods)
-            {
-                method.Body.Optimize();
-            }
+            
 
             List<object> allOpcodes = [];
             allOpcodes.AddRange(usedInstructions);


### PR DESCRIPTION
Implement post-emit IL optimization framework with constant propagation:
- ILOptimizer: orchestrates optimization passes with fixed-point iteration
- ConstantFolder: folds compile-time constant operations (ldc X, ldc Y, op => ldc result)
- Supports i32, i64, f32, f64 arithmetic, bitwise, shift, and comparison operations
- Handles type conversions and unary operations
- Properly updates branch targets when instructions are removed
- Enabled by default via Transformer.EnableOptimizations property