### PR TITLE
Refactor floating point absolute value handling

### DIFF
--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1125,18 +1125,17 @@ namespace Wasm2IL
                             ctx.PopType(1);
                             break;
                         case instr.SELECT:
-                            // select: [a, b, c] -> [c ? a : b]
+                            // select(a,b,c) = a ? b : c
+                            // we have to keep track of the type on top of the stack.
                             var t = ctx.PopType(2);
-                            var helper = ctx.GetHelperVariable(t);
-                            var selectB = il.Create(IlInstr.Nop);
+                            var nextLabel = il.Create(IlInstr.Stloc, ctx.GetHelperVariable(t));
                             endLabel = il.Create(IlInstr.Nop);
-                            il.Emit(IlInstr.Brfalse, selectB); // if c==0, select b
-                            il.Emit(IlInstr.Pop);              // discard b, keep a
+                            il.Emit(IlInstr.Brfalse, nextLabel);
+                            il.Emit(IlInstr.Pop);
                             il.Emit(IlInstr.Br, endLabel);
-                            il.Append(selectB);
-                            il.Emit(IlInstr.Stloc, helper);    // save b
-                            il.Emit(IlInstr.Pop);              // discard a
-                            il.Emit(IlInstr.Ldloc, helper);    // load b
+                            il.Append(nextLabel);
+                            il.Emit(IlInstr.Pop);
+                            il.Emit(IlInstr.Ldloc, ctx.GetHelperVariable(t));
                             il.Append(endLabel);
                             break;
                         case instr.GLOBAL_GET:

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1771,23 +1771,14 @@ namespace Wasm2IL
                             il.Emit(IlInstr.Call, m2);
                             break;
                         case instr.F64_COPYSIGN:
+                            m2 = GetMethodRef(typeof(Math), nameof(Math.CopySign), typeof(double), typeof(double));
+                            il.Emit(IlInstr.Call, m2);
+                            ctx.PopType(1);
+                            break;
                         case instr.F32_COPYSIGN:
-                            var vtype = is64 ? f64Type : f32Type;
-                            il.Emit(IlInstr.Stloc, ctx.GetHelperVariable(vtype));
-                            il.Emit(IlInstr.Stloc, ctx.GetHelperVariable(vtype, 1));
-                            il.Emit(IlInstr.Ldloc, ctx.GetHelperVariable(vtype));
-                            il.Emit(IlInstr.Ldloc, ctx.GetHelperVariable(vtype, 1));
-                            il.Emit(IlInstr.Ldloc, ctx.GetHelperVariable(vtype));
-                            il.Emit(IlInstr.Mul);
-                            if (is64)
-                                il.Emit(IlInstr.Ldc_R8, 0.0);
-                            else
-                                il.Emit(IlInstr.Ldc_R4, 0.0f);
-                            il.Emit(IlInstr.Clt);
-                            label = il.Create(IlInstr.Nop);
-                            il.Emit(IlInstr.Brfalse, label);
-                            il.Emit(IlInstr.Neg);
-                            il.Append(label);
+                            m2 = GetMethodRef(typeof(MathF), nameof(MathF.CopySign), typeof(float), typeof(float));
+                            il.Emit(IlInstr.Call, m2);
+                            ctx.PopType(1);
                             break;
                         case instr.I32_EQZ:
                             var nextI = (instr) reader.Clone().ReadU8();

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1743,23 +1743,15 @@ namespace Wasm2IL
                             break;
                         case instr.F32_ABS:
                         case instr.F64_ABS:
-                            il.Emit(IlInstr.Dup);
-                            if (is64)
-                                il.Emit(IlInstr.Ldc_R8, 0.0);
-                            else
-                                il.Emit(IlInstr.Ldc_R4, 0.0f);
-                            il.Emit(IlInstr.Clt);
-                            var label = il.Create(IlInstr.Nop);
-                            il.Emit(IlInstr.Brfalse, label);
-                            il.Emit(IlInstr.Neg);
-                            il.Append(label);
+                            var m2 = GetMethodRef(typeof(Math), nameof(Math.Abs), InstrType(instr));
+                            il.Emit(IlInstr.Call, m2);
                             break;
                         case instr.F32_MIN:
                         case instr.F64_MIN:
                         case instr.F32_MAX:
                         case instr.F64_MAX:
                             var name = instr.ToString().EndsWith("MAX") ? "Max" : "Min";
-                            var m2 = GetMethodRef(typeof(Math), name, InstrType(instr), InstrType(instr));
+                            m2 = GetMethodRef(typeof(Math), name, InstrType(instr), InstrType(instr));
                             il.Emit(IlInstr.Call, m2);
                             ctx.PopType(1);
                             break;

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1125,17 +1125,18 @@ namespace Wasm2IL
                             ctx.PopType(1);
                             break;
                         case instr.SELECT:
-                            // select(a,b,c) = a ? b : c
-                            // we have to keep track of the type on top of the stack.
+                            // select: [a, b, c] -> [c ? a : b]
                             var t = ctx.PopType(2);
-                            var nextLabel = il.Create(IlInstr.Stloc, ctx.GetHelperVariable(t));
+                            var helper = ctx.GetHelperVariable(t);
+                            var selectB = il.Create(IlInstr.Nop);
                             endLabel = il.Create(IlInstr.Nop);
-                            il.Emit(IlInstr.Brfalse, nextLabel);
-                            il.Emit(IlInstr.Pop);
+                            il.Emit(IlInstr.Brfalse, selectB); // if c==0, select b
+                            il.Emit(IlInstr.Pop);              // discard b, keep a
                             il.Emit(IlInstr.Br, endLabel);
-                            il.Append(nextLabel);
-                            il.Emit(IlInstr.Pop);
-                            il.Emit(IlInstr.Ldloc, ctx.GetHelperVariable(t));
+                            il.Append(selectB);
+                            il.Emit(IlInstr.Stloc, helper);    // save b
+                            il.Emit(IlInstr.Pop);              // discard a
+                            il.Emit(IlInstr.Ldloc, helper);    // load b
                             il.Append(endLabel);
                             break;
                         case instr.GLOBAL_GET:


### PR DESCRIPTION
Replace manual branch-based abs implementation with direct Math.Abs call, consistent with how other math operations (Sqrt, Ceiling, Floor) are handled.