### PR TITLE
Clean up code for clarity and brevity

### DIFF
--- a/Wasm2IL/Dwarf/Parser.cs
+++ b/Wasm2IL/Dwarf/Parser.cs
@@ -118,9 +118,9 @@ internal class Parser
         DwarfForm.DW_FORM_udata => reader.ReadU64Leb(),
         DwarfForm.DW_FORM_string => ReadNullTerminatedString(reader),
         DwarfForm.DW_FORM_strp => reader.ReadU32(),
-        DwarfForm.DW_FORM_flag => reader.ReadByte() != 0,
+        DwarfForm.DW_FORM_flag => reader.ReadU8() != 0,
         DwarfForm.DW_FORM_flag_present => true,
-        DwarfForm.DW_FORM_ref1 => reader.ReadByte(),
+        DwarfForm.DW_FORM_ref1 => reader.ReadU8(),
         DwarfForm.DW_FORM_ref2 => reader.ReadU16(),
         DwarfForm.DW_FORM_ref4 => reader.ReadU32(),
         DwarfForm.DW_FORM_ref8 => reader.ReadU64(),
@@ -144,7 +144,7 @@ internal class Parser
     {
         var bytes = new List<byte>();
         byte b;
-        while ((b = reader.ReadByte()) != 0)
+        while ((b = reader.ReadU8()) != 0)
             bytes.Add(b);
         return System.Text.Encoding.UTF8.GetString(bytes.ToArray());
     }

--- a/Wasm2IL/Lib.cs
+++ b/Wasm2IL/Lib.cs
@@ -11,16 +11,12 @@ namespace Wasm2IL;
 public static partial class Lib
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe byte* Alloc(int size)
-    {
-        throw new Exception("!!");
-    }
+    public static unsafe byte* Alloc(int size) =>
+        throw new NotImplementedException("Alloc not available - WASM module should provide malloc");
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe byte* Realloc(byte* ptr, int size)
-    {
-        throw new Exception("!!");
-    }
+    public static unsafe byte* Realloc(byte* ptr, int size) =>
+        throw new NotImplementedException("Realloc not available - WASM module should provide realloc");
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void MemoryFill(void* loc, int value, int N)
@@ -711,11 +707,6 @@ public static partial class Lib
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void v128_store64_lane(long* a, int lane, Vector128<long> v) => *a = v.GetElement(lane);
 
-    public static Vector128<byte> not_implemented_vec128_vec128(Vector128<byte> a)
-    {
-        throw new NotImplementedException();
-    }
-
     [WasmOpcode(ExtendedInstruction.I32_TRUNC_SAT_F32_S)]
     public static int I32_TRUNC_SAT_F32_S(float f)
     {
@@ -804,22 +795,7 @@ public static partial class Lib
     }
 }
 
-public class WasmOpcodeAttribute : Attribute
+public class WasmOpcodeAttribute(object key) : Attribute
 {
-    public object Key { get; }
-
-    public WasmOpcodeAttribute(VectorInstructions vectorInstruction)
-    {
-        Key = vectorInstruction;
-    }
-
-    public WasmOpcodeAttribute(Instruction instruction)
-    {
-        Key = instruction;
-    }
-
-    public WasmOpcodeAttribute(ExtendedInstruction instruction)
-    {
-        Key = instruction;
-    }
+    public object Key { get; } = key;
 }

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1737,6 +1737,7 @@ namespace Wasm2IL
 
                         case instr.VECTOR_INSTRUCTION:
                             var instr2 = (VectorInstructions) reader.ReadU32Leb();
+                            VariableDefinition? stvar = null;
                             switch (instr2)
                             {
                                 case VectorInstructions.V128_STORE:

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -66,12 +66,12 @@ namespace Wasm2IL
 
         public VariableDefinition GetHelperVariable(TypeReference tr, int idx = 0)
         {
-            if (!HelperVars.ContainsKey(idx))
-                HelperVars[idx] = new();
-            var dict = HelperVars[idx];
-            if (tr == VoidType) throw new Exception("void type");
-            if (dict.TryGetValue(tr, out var x))
-                return x;
+            if (!HelperVars.TryGetValue(idx, out var dict))
+                HelperVars[idx] = dict = new();
+            if (tr == VoidType)
+                throw new InvalidOperationException("Cannot get helper variable for void type");
+            if (dict.TryGetValue(tr, out var existing))
+                return existing;
             var v = new VariableDefinition(tr);
             Method.Body.Variables.Add(v);
             dict[tr] = v;
@@ -80,19 +80,17 @@ namespace Wasm2IL
 
         public void PushType(TypeReference? tr)
         {
-            if (tr == null) throw new Exception("??");
+            if (tr == null)
+                throw new ArgumentNullException(nameof(tr));
             if (tr != VoidType)
                 TypeStack.Push(tr);
         }
 
         public TypeReference PopType(int count = 1)
         {
-            if (count == 0) return default;
-            while (count > 1)
-            {
+            if (count == 0) return default!;
+            while (count-- > 1)
                 TypeStack.Pop();
-                count--;
-            }
             return TypeStack.Pop();
         }
 
@@ -280,7 +278,7 @@ namespace Wasm2IL
             var reader = new BinReader(str2);
             var header = reader.ReadStrl(4);
             if (magicHeader != header)
-                throw new Exception("invalid header");
+                throw new TransformException("Invalid WASM header");
             var wasmVersion = new byte[4];
             reader.Read(wasmVersion);
             if (!wasmVersion.SequenceEqual((byte[])[1, 0, 0, 0]))
@@ -462,84 +460,73 @@ namespace Wasm2IL
             }
         }
 
-        private void ReadElementSection(BinReader reader)
+        void ReadElementSection(BinReader reader)
         {
             var cnt = reader.ReadU32Leb();
             for (int i = 0; i < cnt; i++)
             {
                 var tableIndex = reader.ReadU32Leb();
                 if (tableIndex != 0)
-                    throw new Exception("Multiple tables are not supported");
-                var instr2 = (instr) reader.ReadU8();
-                if (instr2 == instr.VECTOR_INSTRUCTION)
-                {
-                    var ext2 = reader.ReadU8();
-                    instr2 = (instr) (0xFD00 | ext2);
-                }
+                    throw new NotSupportedException("Multiple tables not supported");
 
-                Assert.AreEqual(Wasm.Instruction.I32_CONST, instr2);
+                var op = (instr)reader.ReadU8();
+                if (op == instr.VECTOR_INSTRUCTION)
+                    op = (instr)(0xFD00 | reader.ReadU8());
+                if (op != instr.I32_CONST)
+                    throw new TransformException($"Expected I32_CONST in element section, got {op}");
+
                 var elementOffset = reader.ReadU32Leb();
-                var end = (instr) reader.ReadU8();
+                var end = (instr)reader.ReadU8();
                 if (end != instr.END)
-                    throw new Exception("Expected END opcode");
-                var fncCnt = reader.ReadU32Leb();
+                    throw new TransformException($"Expected END opcode in element section, got {end}");
 
+                var funcCount = reader.ReadU32Leb();
                 var ctor = cls.GetStaticConstructor();
                 ctor.Body.Instructions.RemoveAt(ctor.Body.Instructions.Count - 1);
                 var il = ctor.Body.GetILProcessor();
-                il.Emit(OpCodes.Ldc_I4, (int) fncCnt + 1);
+                il.Emit(OpCodes.Ldc_I4, (int)funcCount + 1);
                 il.Emit(OpCodes.Newarr, def.MainModule.TypeSystem.Object);
                 il.Emit(OpCodes.Stsfld, functionTable);
 
-                for (var i2 = 0; i2 < fncCnt; i2++)
+                for (var j = 0; j < funcCount; j++)
                 {
                     il.Emit(OpCodes.Ldsfld, functionTable);
-                    il.Emit(OpCodes.Ldc_I4, (int)(i2 + elementOffset));
-
+                    il.Emit(OpCodes.Ldc_I4, (int)(j + elementOffset));
                     il.Emit(OpCodes.Ldnull);
+
                     var funcId = reader.ReadU32Leb();
+                    MethodReference method;
+                    TypeId typeId;
+
                     if (funcId < ImportFuncs.Count)
                     {
                         var imp = ImportFuncs[funcId];
-                        var t = Types[(uint) imp.TypeId];
+                        typeId = Types[(uint)imp.TypeId!];
                         if (imp.Method == null)
                         {
-                            var method = ResolveImportedMethod(imp.Module, imp.Name);
-                            if (method != null)
+                            var resolved = ResolveImportedMethod(imp.Module, imp.Name);
+                            if (resolved != null)
                             {
-                                var reference = method is MethodReference mr
-                                    ? mr
-                                    : def.MainModule.ImportReference((MethodInfo) method);
-                                reference = MaybeWrap(reference);
-                                imp.Method = reference;
+                                var reference = resolved is MethodReference mr
+                                    ? mr : def.MainModule.ImportReference((MethodInfo)resolved);
+                                imp.Method = MaybeWrap(reference);
                             }
                         }
-
-                        if (imp.Method == null)
-                            throw new InvalidOperationException($"Failed to resolve imported function: {imp.Module}.{imp.Name}");
-
-                        {
-                            il.Emit(OpCodes.Ldftn, imp.Method);
-                            var ftype = typeToFunc(t);
-                            var constr = ftype.GetConstructors().First();
-                            var cref = def.MainModule.ImportReference(constr);
-                            il.Emit(OpCodes.Newobj, cref);
-                            il.Emit(OpCodes.Stelem_Any, def.MainModule.TypeSystem.Object);
-                        }
+                        method = imp.Method
+                            ?? throw new TransformException($"Failed to resolve import: {imp.Module}.{imp.Name}");
                     }
                     else
                     {
-                        var importFunc = FuncDecl[(uint) (funcId - ImportFuncs.Count)];
-                        var t = Types[importFunc.TypeId];
-                        il.Emit(OpCodes.Ldftn, FuncDecl[(uint) (funcId - ImportFuncs.Count)].Method);
-                        var ftype = typeToFunc(t);
-                        var constr = ftype.GetConstructors().First();
-                        var cref = def.MainModule.ImportReference(constr);
-                        il.Emit(OpCodes.Newobj, cref);
-                        il.Emit(OpCodes.Stelem_Any, def.MainModule.TypeSystem.Object);
+                        var funcDecl = FuncDecl[(uint)(funcId - ImportFuncs.Count)];
+                        typeId = Types[funcDecl.TypeId];
+                        method = funcDecl.Method!;
                     }
-                }
 
+                    il.Emit(OpCodes.Ldftn, method);
+                    var delegateType = typeToFunc(typeId);
+                    il.Emit(OpCodes.Newobj, def.MainModule.ImportReference(delegateType.GetConstructors().First()));
+                    il.Emit(OpCodes.Stelem_Any, def.MainModule.TypeSystem.Object);
+                }
                 il.Emit(IlInstr.Ret);
             }
         }
@@ -592,28 +579,26 @@ namespace Wasm2IL
             {
                 uint memidx = reader.ReadU32Leb();
                 if (memidx != 0)
-                    throw new Exception("Multipe memories are not supported");
+                    throw new NotSupportedException("Multiple memories not supported");
 
                 int offset = 0;
                 while (true)
                 {
-                    var instr = (instr) reader.ReadU8();
-                    switch (instr)
+                    var op = (instr)reader.ReadU8();
+                    switch (op)
                     {
                         case instr.I32_CONST:
-                            var _offset = (int) reader.ReadI64Leb();
-                            offset = _offset;
+                            offset = (int)reader.ReadI64Leb();
                             break;
                         case instr.GLOBAL_GET:
                             throw new NotSupportedException("GLOBAL_GET in data section offset expression not supported");
                         case instr.END:
                             goto read_end;
                         default:
-                            throw new Exception("Unknown instruction");
+                            throw new TransformException($"Unsupported instruction {op} in data section offset expression");
                     }
                 }
-
-                read_end: ;
+                read_end:
                 // load the data into the heap one byte at a time.
                 // consider finding a way to load it based on static data instead.
                 uint byteCount = reader.ReadU32Leb();
@@ -658,11 +643,11 @@ namespace Wasm2IL
             }
         }
 
-        class LabelType
+        class LabelType(byte type, Instruction? endLabel, Instruction? startLabel)
         {
-            public byte Type;
-            public Instruction? EndLabel;
-            public Instruction? StartLabel;
+            public byte Type = type;
+            public Instruction? EndLabel = endLabel;
+            public Instruction? StartLabel = startLabel;
         }
 
         MethodReference? resolveMethod(uint func)
@@ -818,8 +803,7 @@ namespace Wasm2IL
                 m1.Body.Variables.Add(new VariableDefinition(def.MainModule.TypeSystem.Int32)); // heapaddr
                 m1.Body.Variables.Add(heapVar);
                 
-                var labelStack = new List<LabelType>();
-                labelStack.Add(new LabelType());
+                var labelStack = new List<LabelType> { new(0, null, null) };
 
                 while (next > reader.Position)
                 {
@@ -874,36 +858,38 @@ namespace Wasm2IL
                             ctx.PushType(ftp.ReturnType);
                             break;
                         case instr.BLOCK:
+                        {
                             var blockType = reader.ReadU8();
                             var endLabel = il.Create(OpCodes.Nop);
-                            var blk = new LabelType { Type = blockType, EndLabel = endLabel, StartLabel = endLabel };
-                            labelStack.Add(blk);
+                            labelStack.Add(new LabelType(blockType, endLabel, endLabel));
                             break;
+                        }
                         case instr.LOOP:
-                            blockType = reader.ReadU8();
+                        {
+                            var blockType = reader.ReadU8();
                             var startLabel = il.Create(OpCodes.Nop);
                             il.Append(startLabel);
-                            blk = new LabelType {Type = blockType, EndLabel = null, StartLabel = startLabel};
-                            labelStack.Add(blk);
+                            labelStack.Add(new LabelType(blockType, null, startLabel));
                             break;
-                        case instr.IF:
-                            blockType = reader.ReadU8();
-                        {
-                            endLabel = il.Create(OpCodes.Nop);
-                            il.Emit(IlInstr.Brfalse, endLabel);
-                            blk = new LabelType {Type = blockType, EndLabel = endLabel, StartLabel = null};
-                            labelStack.Add(blk);
                         }
+                        case instr.IF:
+                        {
+                            var blockType = reader.ReadU8();
+                            var endLabel = il.Create(OpCodes.Nop);
+                            il.Emit(IlInstr.Brfalse, endLabel);
+                            labelStack.Add(new LabelType(blockType, endLabel, null));
                             break;
+                        }
                         case instr.ELSE:
-                            endLabel = il.Create(OpCodes.Nop);
+                        {
+                            var endLabel = il.Create(OpCodes.Nop);
                             il.Emit(OpCodes.Br, endLabel);
-                            blk = labelStack.Last();
-                            labelStack.Remove(blk);
+                            var blk = labelStack[^1];
+                            labelStack.RemoveAt(labelStack.Count - 1);
                             il.Append(blk.EndLabel);
-                            blk = new LabelType {Type = blk.Type, EndLabel = endLabel, StartLabel = null};
-                            labelStack.Add(blk);
+                            labelStack.Add(new LabelType(blk.Type, endLabel, null));
                             break;
+                        }
 
                         case instr.BR:
                         case instr.BR_IF:
@@ -920,38 +906,38 @@ namespace Wasm2IL
 
                             break;
                         case instr.BR_TABLE:
+                        {
                             var cnt = reader.ReadU32Leb();
                             var items = new Instruction[cnt];
                             for (int i2 = 0; i2 < cnt; i2++)
                             {
                                 var brindex2 = reader.ReadU32Leb();
-                                var brindex3 = (int) (labelStack.Count - brindex2 - 1);
-                                items[i2] = labelStack[brindex3].StartLabel;
+                                items[i2] = labelStack[labelStack.Count - (int)brindex2 - 1].StartLabel!;
                             }
-
                             var defaultLabelIndex = reader.ReadU32Leb();
-                            var defaultLabel = labelStack[(int) (labelStack.Count - defaultLabelIndex - 1)].StartLabel;
+                            var defaultLabel = labelStack[labelStack.Count - (int)defaultLabelIndex - 1].StartLabel
+                                ?? throw new TransformException("BR_TABLE default label not found");
                             il.Emit(OpCodes.Switch, items);
-                            if (defaultLabel == null)
-                                throw new Exception("Unexpected situation");
                             il.Emit(OpCodes.Br, defaultLabel);
-
                             ctx.PopType(1);
                             break;
+                        }
                         case instr.SELECT:
-                            // select(a,b,c) = a ? b : c
-                            // we have to keep track of the type on top of the stack.
+                        {
+                            // select(cond, a, b) = cond ? a : b
                             var t = ctx.PopType(2);
-                            var nextLabel = il.Create(IlInstr.Stloc, ctx.GetHelperVariable(t));
-                            endLabel = il.Create(IlInstr.Nop);
-                            il.Emit(IlInstr.Brfalse, nextLabel);
+                            var helper = ctx.GetHelperVariable(t);
+                            var keepSecond = il.Create(IlInstr.Stloc, helper);
+                            var endLabel = il.Create(IlInstr.Nop);
+                            il.Emit(IlInstr.Brfalse, keepSecond);
                             il.Emit(IlInstr.Pop);
                             il.Emit(IlInstr.Br, endLabel);
-                            il.Append(nextLabel);
+                            il.Append(keepSecond);
                             il.Emit(IlInstr.Pop);
-                            il.Emit(IlInstr.Ldloc, ctx.GetHelperVariable(t));
+                            il.Emit(IlInstr.Ldloc, helper);
                             il.Append(endLabel);
                             break;
+                        }
                         case instr.GLOBAL_GET:
                             var offset2 = reader.ReadU32Leb();
                             var glob = globals[offset2];
@@ -1097,35 +1083,32 @@ namespace Wasm2IL
                         case instr.I64_STORE_16:
                         case instr.F32_STORE:
                         case instr.F64_STORE:
-                            reader.ReadU32Leb(); // align hint (ignored)
+                        {
+                            reader.ReadU32Leb(); // alignment hint (unused - loads/stores are unaligned)
                             var offset = reader.ReadU32Leb();
-                            VariableDefinition stvar = null;
-                            if (instr.ToString().Contains("STORE"))
+                            VariableDefinition? stvar = null;
+                            var instrName = instr.ToString();
+                            if (instrName.Contains("STORE"))
                             {
-                                if (instr.ToString().Contains("F32"))
-                                    stvar = ctx.GetHelperVariable(f32Type);
-                                else if (instr.ToString().Contains("F64"))
-                                    stvar = ctx.GetHelperVariable(f64Type);
-                                else if (instr.ToString().Contains("I64"))
-                                    stvar = ctx.GetHelperVariable(i64Type);
-                                else if (instr.ToString().Contains("I32"))
-                                    stvar = ctx.GetHelperVariable(i32Type);
-                                else throw new Exception("Unknown type");
+                                stvar = ctx.GetHelperVariable(
+                                    instrName.Contains("F32") ? f32Type :
+                                    instrName.Contains("F64") ? f64Type :
+                                    instrName.Contains("I64") ? i64Type :
+                                    instrName.Contains("I32") ? i32Type :
+                                    throw new TransformException($"Unknown store type: {instr}"));
                                 il.Emit(IlInstr.Stloc, stvar);
                                 ctx.PopType(1);
                             }
 
-                            // adjust according to the offset 
                             if (offset != 0)
                             {
                                 il.Emit(IlInstr.Ldc_I4, (int)offset);
                                 il.Emit(IlInstr.Add);
                             }
-                            
                             ctx.LoadMemory();
                             il.Emit(IlInstr.Add);
 
-                            
+
 
                             switch (instr)
                             {
@@ -1220,10 +1203,10 @@ namespace Wasm2IL
                                     il.Emit(IlInstr.Conv_U8);
                                     break;
                                 default:
-                                    throw new Exception("Unexpected opcode");
+                                    throw new UnreachableException();
                             }
-
                             break;
+                        }
                         case instr.I64_EXTEND_I32_U:
                             il.Emit(IlInstr.Conv_U8);
                             ctx.PopType(1);
@@ -2286,58 +2269,40 @@ namespace Wasm2IL
             Log.WriteLine("Globals: {0}", globals.Count);
         }
 
-        unsafe void ReadMemorySection(BinReader reader)
+        void ReadMemorySection(BinReader reader)
         {
             var memCount = reader.ReadU32Leb();
-            Assert.AreEqual<uint>(1, memCount);
-            for (uint i = 0; i < memCount; i++)
-            {
-                var type = reader.ReadU8();
-                var min = reader.ReadU32Leb();
-                if (type == 0)
-                {
-                    Log.WriteLine("Memory: {0} pages", min);
-                    var cctoril = cls.GetStaticConstructor().Body.GetILProcessor();
-                    cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
-                    cctoril.Emit(OpCodes.Ldc_I4, (int) (min * page_size));
-                    // Allocate 4GB of virtual memory so we'll never have to move the heap pointer.
-                    cctoril.Emit(OpCodes.Ldc_I8, 4L * 1024L * 1024L * 1024L);
-                    cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
-                    cctoril.Emit(OpCodes.Stsfld, memoryField);
-                    cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
-                    cctoril.Emit(OpCodes.Ret);
-                }
-                else if (type == 1)
-                {
-                    var max = reader.ReadU32Leb();
+            if (memCount != 1)
+                throw new NotSupportedException($"Expected 1 memory, got {memCount}");
 
-                    Log.WriteLine("Memory of {0}-{1} pages ({2} - {3})", min, max, min * page_size,
-                        max * page_size);
-                    var cctoril = cls.GetStaticConstructor().Body.GetILProcessor();
-                    cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
+            var limitType = reader.ReadU8();
+            var min = reader.ReadU32Leb();
+            uint? max = limitType == 1 ? reader.ReadU32Leb() : null;
 
-                    // Allocate 4GB of virtual memory so we'll never have to move the heap pointer.
-                    cctoril.Emit(OpCodes.Ldc_I8, 4L * 1024L * 1024L * 1024L);
-                    cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
-                    cctoril.Emit(OpCodes.Stsfld, memoryField);
-                    cctoril.Emit(OpCodes.Ldc_I4, (int) (min * page_size));
-                    cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
+            Log.WriteLine(max.HasValue
+                ? $"Memory: {min}-{max} pages ({min * page_size} - {max * page_size} bytes)"
+                : $"Memory: {min} pages ({min * page_size} bytes)");
 
-                    cctoril.Emit(OpCodes.Ret);
-                }
-            }
+            var il = cls.GetStaticConstructor().Body.GetILProcessor();
+            il.Body.Instructions.RemoveAt(il.Body.Instructions.Count - 1);
+
+            // Reserve 4GB virtual address space so heap never needs to move
+            il.Emit(OpCodes.Ldc_I8, 4L * 1024 * 1024 * 1024);
+            il.EmitCall(() => MemoryAllocator.AllocateMemory);
+            il.Emit(OpCodes.Stsfld, memoryField);
+            il.Emit(OpCodes.Ldc_I4, (int)(min * page_size));
+            il.Emit(OpCodes.Stsfld, memoryFieldSize);
+            il.Emit(OpCodes.Ret);
         }
 
-        void EmitCall(ILProcessor gen, Expression expr)
+        void EmitCall(ILProcessor il, Expression expr)
         {
-            var f =
-                (((expr as LambdaExpression).Body as UnaryExpression).Operand as MethodCallExpression).Object as
-                ConstantExpression;
-            var method = (MethodInfo) f.Value;
-            var declType = gen.Body.Method.DeclaringType;
-            var reference = declType.Module.ImportReference(method);
-            reference = MaybeWrap(reference);
-            gen.Emit(OpCodes.Call, reference);
+            var body = ((LambdaExpression)expr).Body;
+            var operand = ((UnaryExpression)body).Operand;
+            var constant = (ConstantExpression)((MethodCallExpression)operand).Object!;
+            var method = (MethodInfo)constant.Value!;
+            var reference = il.Body.Method.DeclaringType!.Module.ImportReference(method);
+            il.Emit(OpCodes.Call, MaybeWrap(reference));
         }
 
         void ReadFunctionSection(BinReader reader)

--- a/Wasm2IL/Utils/Assert.cs
+++ b/Wasm2IL/Utils/Assert.cs
@@ -1,43 +1,30 @@
-namespace Wasm2IL
+namespace Wasm2IL;
+
+static class Assert
 {
-    static class Assert
+    class AssertException(string message) : Exception(message);
+
+    public static void AreEqual<T>(T expected, T actual)
     {
+        if (!Equals(expected, actual))
+            throw new AssertException($"Expected {expected}, got {actual}");
+    }
 
-        class AssertException : Exception
-        {
+    public static void AreEqual(float expected, float actual, float tolerance = 0.0001f)
+    {
+        if (Math.Abs(expected - actual) > tolerance)
+            throw new AssertException($"Expected {expected}, got {actual}");
+    }
 
-        }
-        
+    public static void AreEqual(double expected, double actual, double tolerance = 0.00001)
+    {
+        if (Math.Abs(expected - actual) > tolerance)
+            throw new AssertException($"Expected {expected}, got {actual}");
+    }
 
-        public static void AreEqual<T>(T a, T b)
-        {
-            if (Equals(a, b) == false)
-                throw new AssertException();
-        }
-        public static void AreEqual(float a, float b)
-        {
-            float d = 0.0001f;
-            if (Math.Abs(a - b) > d)
-                throw new AssertException();
-        }
-        
-        public static void AreEqual(double a, double b)
-        {
-            double d = 0.00001;
-            if (Math.Abs(a - b) > d)
-                throw new AssertException();
-        }
-
-        public static void AreEqual(string a, string b)
-        {
-            if (Equals(a, b) == false)
-                throw new AssertException();
-        }
-
-        public static void IsTrue(bool v)
-        {
-            if (v == false)
-                throw new AssertException();
-        }
+    public static void IsTrue(bool condition, string message = "Assertion failed")
+    {
+        if (!condition)
+            throw new AssertException(message);
     }
 }

--- a/Wasm2IL/Utils/BinReader.cs
+++ b/Wasm2IL/Utils/BinReader.cs
@@ -2,15 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace Wasm2IL;
 
-using u64 = UInt64;
-using u32 = UInt32;
-using i64 = Int64;
-using i32 = Int32;
-using i16 = Int16;
-using u8 = Byte;
-using u16 = UInt16;
-
-internal class BinReader
+class BinReader
 {
     static System.Text.Encoding Utf8 => System.Text.Encoding.UTF8;
     readonly MemoryStream membuffer = new();
@@ -42,42 +34,41 @@ internal class BinReader
 
     public bool IsAtEnd => position == length;
 
-    public u8 ReadU8() => data[position++];
+    public byte ReadU8() => data[position++];
 
-    public byte ReadByte() => ReadU8();
+    public uint ReadU32Leb() => (uint)ReadU64Leb();
 
-    public u32 ReadU32Leb() => (u32)ReadU64Leb();
-
-    public u64 ReadU64Leb()
+    public ulong ReadU64Leb()
     {
-        u8 chunk;
-        u64 value = 0;
-        u32 offset = 0;
+        byte chunk;
+        ulong value = 0;
+        int offset = 0;
         while ((chunk = ReadU8()) > 0)
         {
-            value |= (u64)((0b01111111L & chunk) << (i32)offset);
+            value |= (ulong)(0x7F & chunk) << offset;
             offset += 7;
-            if ((0b10000000L & chunk) == 0)
+            if ((0x80 & chunk) == 0)
                 break;
         }
         return value;
     }
 
-    public i64 ReadI64Leb()
+    public long ReadI64Leb()
     {
         unchecked
         {
-            i64 value = 0;
-            u32 shift = 0;
-            u8 chunk;
+            long value = 0;
+            int shift = 0;
+            byte chunk;
             do
             {
                 chunk = ReadU8();
-                value |= ((i64)(chunk & 0x7f)) << (i32)shift;
+                value |= (long)(chunk & 0x7F) << shift;
                 shift += 7;
             } while (chunk >= 128);
+
             if (shift < 64 && (chunk & 0x40) != 0)
-                value |= (i64)0xFFFFFFFFFFFFFFFFL << (i32)shift;
+                value |= -1L << shift;
             return value;
         }
     }
@@ -92,11 +83,11 @@ internal class BinReader
 
     public long ReadI64() => ReadT<long>();
     public ulong ReadU64() => ReadT<ulong>();
-    internal short ReadI16() => ReadT<i16>();
-    internal ushort ReadU16() => ReadT<u16>();
-    internal int ReadI32() => ReadT<i32>();
-    internal uint ReadU32() => ReadT<u32>();
-    internal float ReadF32() => ReadT<float>();
+    public short ReadI16() => ReadT<short>();
+    public ushort ReadU16() => ReadT<ushort>();
+    public int ReadI32() => ReadT<int>();
+    public uint ReadU32() => ReadT<uint>();
+    public float ReadF32() => ReadT<float>();
     public double ReadF64() => ReadT<double>();
 
     T ReadT<T>() where T : struct
@@ -121,8 +112,8 @@ internal class BinReader
 
     public string ReadStrN()
     {
-        membuffer.Seek(0, SeekOrigin.Begin);
         var len = (int)ReadU64Leb();
+        membuffer.Seek(0, SeekOrigin.Begin);
         Span<byte> buffer = stackalloc byte[100];
         while (len > 0)
         {
@@ -160,26 +151,5 @@ internal class BinReader
         var buffer = new byte[n];
         Read(buffer);
         return buffer;
-    }
-
-    public long ReadSLeb64()
-    {
-        long result = 0;
-        int shift = 0;
-        byte b;
-
-        while (true)
-        {
-            b = ReadByte();
-            result |= (long)(b & 0x7F) << shift;
-            shift += 7;
-            if ((b & 0x80) == 0)
-                break;
-        }
-
-        if (shift < 64 && (b & 0x40) != 0)
-            result |= -(1L << shift);
-
-        return result;
     }
 }

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
@@ -19,7 +18,7 @@ public class WasmAssembly
     readonly FieldInfo memory;
     readonly FieldInfo memorySize;
     readonly FieldInfo? functionTable;
-    readonly List<int> freeFunctions = new();
+    readonly List<int> freeFunctions = [];
     object[]? functionTableArray;
 
     public string Name => code.Name;
@@ -55,7 +54,7 @@ public class WasmAssembly
         }
 
         var newIdx = functionTableArray.Length;
-        functionTableArray = [.. functionTableArray, d];
+        functionTableArray = [..functionTableArray, d];
         functionTable.SetValue(null, functionTableArray);
         return newIdx;
     }
@@ -68,24 +67,15 @@ public class WasmAssembly
         freeFunctions.Add(idx);
     }
 
-    public int Malloc(int len)
-    {
-        if (malloc == null)
-            return FakeMalloc(len);
-        return (int)malloc.Invoke(null, [len])!;
-    }
+    public int Malloc(int len) => malloc != null ? (int)malloc.Invoke(null, [len])! : FakeMalloc(len);
 
-    public void Free(int ptr)
-    {
-        if (free == null) return;
-        free.Invoke(null, [ptr]);
-    }
+    public void Free(int ptr) => free?.Invoke(null, [ptr]);
 
-    public unsafe int FakeMalloc(int len)
+    public int FakeMalloc(int len)
     {
-        int memSize = (int)memorySize.GetValue(null)!;
-        memorySize.SetValue(null, memSize + len);
-        return memSize;
+        int current = (int)memorySize.GetValue(null)!;
+        memorySize.SetValue(null, current + len);
+        return current;
     }
 
     public unsafe Span<byte> GetHeap()
@@ -99,40 +89,41 @@ public class WasmAssembly
 
     public static unsafe void StringToHeap2(byte* buffer, string str)
     {
-        var bc = System.Text.Encoding.UTF8.GetByteCount(str);
-        var span = new Span<byte>(buffer, bc + 1);
-        span[bc] = 0;
+        var len = System.Text.Encoding.UTF8.GetByteCount(str);
+        var span = new Span<byte>(buffer, len + 1);
+        span[len] = 0;
         System.Text.Encoding.UTF8.GetBytes(str, span);
     }
 
     public int StringToHeap(string str)
     {
-        var bc = System.Text.Encoding.UTF8.GetByteCount(str);
-        int s = Malloc(bc + 1);
-        var span = GetHeap().Slice(s, bc + 1);
-        span[bc] = 0;
+        var len = System.Text.Encoding.UTF8.GetByteCount(str);
+        int ptr = Malloc(len + 1);
+        var span = GetHeap().Slice(ptr, len + 1);
+        span[len] = 0;
         System.Text.Encoding.UTF8.GetBytes(str, span);
-        return s;
+        return ptr;
     }
 
     public object? Invoke(string methodName, params object[] args)
     {
-        var toFree = ImmutableList<int>.Empty;
-        var fcnToFree = ImmutableList<int>.Empty;
+        List<int> stringsToFree = [];
+        List<int> functionsToFree = [];
 
         for (int i = 0; i < args.Length; i++)
         {
-            if (args[i] is string str)
+            switch (args[i])
             {
-                var ptr = StringToHeap(str);
-                args[i] = ptr;
-                toFree = toFree.Add(ptr);
-            }
-            else if (args[i] is Delegate d)
-            {
-                var idx = AssignCallbackFunction(d);
-                args[i] = idx;
-                fcnToFree = fcnToFree.Add(idx);
+                case string str:
+                    var ptr = StringToHeap(str);
+                    args[i] = ptr;
+                    stringsToFree.Add(ptr);
+                    break;
+                case Delegate d:
+                    var idx = AssignCallbackFunction(d);
+                    args[i] = idx;
+                    functionsToFree.Add(idx);
+                    break;
             }
         }
 
@@ -140,48 +131,39 @@ public class WasmAssembly
             ?? throw new InvalidOperationException($"Method '{methodName}' not found");
         var result = m.Invoke(null, args);
 
-        foreach (var ptr in toFree)
-            Free(ptr);
-        foreach (var fcn in fcnToFree)
-            FreeCallbackFunction(fcn);
+        foreach (var ptr in stringsToFree) Free(ptr);
+        foreach (var idx in functionsToFree) FreeCallbackFunction(idx);
 
         return result;
     }
 
     public MethodInfo? GetMethod(string name) => code.GetMethod(name);
     public FieldInfo? GetField(string name) => code.GetField(name);
+    public Span<byte> GetHeapSpan(int offset, int len) => GetHeap().Slice(offset, len);
 
-    public Span<byte> GetHeapSpan(int i, int len) => GetHeap().Slice(i, len);
+    public Span<T> GetHeapSpan<T>(int offset, int count) where T : struct =>
+        MemoryMarshal.Cast<byte, T>(GetHeap().Slice(offset, count * Marshal.SizeOf<T>()));
 
-    public Span<T> GetHeapSpan<T>(int i, int len) where T : struct =>
-        MemoryMarshal.Cast<byte, T>(GetHeap().Slice(i, len * Marshal.SizeOf<T>()));
-
-    public T GetHeapObject<T>(int ptr) where T : struct
-    {
-        var size = Marshal.SizeOf<T>();
-        return MemoryMarshal.Cast<byte, T>(GetHeapSpan(ptr, size))[0];
-    }
+    public T GetHeapObject<T>(int ptr) where T : struct =>
+        MemoryMarshal.Cast<byte, T>(GetHeapSpan(ptr, Marshal.SizeOf<T>()))[0];
 
     public string GetHeapString(int ptr) => new CString(GetHeap(), ptr).ToString();
 
     public static int ReadOnlySpanLength(ReadOnlySpan<byte> span) => span.Length;
     public static int SpanLength(Span<byte> span) => span.Length;
 
-    public static unsafe void CopyFromSpan(byte* data, Span<byte> span) =>
-        span.CopyTo(new Span<byte>(data, span.Length));
+    public static unsafe void CopyFromSpan(byte* dest, Span<byte> src) =>
+        src.CopyTo(new Span<byte>(dest, src.Length));
 
-    public static unsafe void CopyFromReadOnlySpan(byte* data, ReadOnlySpan<byte> span) =>
-        span.CopyTo(new Span<byte>(data, span.Length));
+    public static unsafe void CopyFromReadOnlySpan(byte* dest, ReadOnlySpan<byte> src) =>
+        src.CopyTo(new Span<byte>(dest, src.Length));
 
-    public static unsafe void CopyToSpan(Span<byte> span, byte* data) =>
-        new Span<byte>(data, span.Length).CopyTo(span);
+    public static unsafe void CopyToSpan(Span<byte> dest, byte* src) =>
+        new Span<byte>(src, dest.Length).CopyTo(dest);
 
-    public object? LookupFunction(int i)
-    {
-        var ftable = code.GetField("FunctionTable", BindingFlags.Static | BindingFlags.NonPublic)
-            ?.GetValue(null) as Array;
-        return ftable?.GetValue(i);
-    }
+    public object? LookupFunction(int i) =>
+        (code.GetField("FunctionTable", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.GetValue(null) as Array)?.GetValue(i);
 
     public T AsImplementation<T>()
     {
@@ -190,7 +172,6 @@ public class WasmAssembly
             throw new ArgumentException($"Type {t.Name} must be an interface", nameof(T));
 
         var typeName = t.Name + "Wrapper";
-
         if (ModuleBuilder.GetType(typeName) is { } existingType)
             return (T)Activator.CreateInstance(existingType)!;
 
@@ -207,12 +188,9 @@ public class WasmAssembly
                 ?? throw new InvalidOperationException($"Static method '{targetName}' not found in {code.Name}");
 
             if (method.ReturnType == typeof(void) && staticMethod.ReturnType != typeof(void))
-                throw new ImplementException(
-                    $"Interface specifies void return but {staticMethod.Name} returns a value");
-
+                throw new ImplementException($"Interface specifies void return but {staticMethod.Name} returns a value");
             if (method.ReturnType != typeof(void) && staticMethod.ReturnType == typeof(void))
-                throw new ImplementException(
-                    $"Interface specifies return value but {staticMethod.Name} returns void");
+                throw new ImplementException($"Interface specifies return value but {staticMethod.Name} returns void");
 
             var methodBuilder = typeBuilder.DefineMethod(
                 method.Name,
@@ -226,8 +204,8 @@ public class WasmAssembly
                 il.Emit(OpCodes.Ldsfld, memory);
 
             var parameters = method.GetParameters();
-            List<LocalBuilder> freeLocals = new();
-            List<(LocalBuilder, int)> copyBack = new();
+            List<LocalBuilder> freeLocals = [];
+            List<(LocalBuilder, int)> copyBack = [];
 
             for (int i = 0; i < parameters.Length; i++)
             {
@@ -299,10 +277,10 @@ public class WasmAssembly
             LocalBuilder? retLoc = null;
             il.Emit(OpCodes.Call, staticMethod);
 
-            foreach (var (l, idx) in copyBack)
+            foreach (var (loc, argIdx) in copyBack)
             {
-                il.Emit(OpCodes.Ldarg, idx);
-                il.Emit(OpCodes.Ldloc, l);
+                il.Emit(OpCodes.Ldarg, argIdx);
+                il.Emit(OpCodes.Ldloc, loc);
                 il.Emit(OpCodes.Ldsfld, memory);
                 il.Emit(OpCodes.Add);
                 il.EmitCall(OpCodes.Call, GetType().GetMethod(nameof(CopyToSpan))!, null);
@@ -336,7 +314,4 @@ public class WasmAssembly
     }
 }
 
-public class ImplementException : Exception
-{
-    public ImplementException(string s) : base(s) { }
-}
+public class ImplementException(string message) : Exception(message);


### PR DESCRIPTION
- Assert.cs: Use primary constructor, add meaningful error messages
- BinReader.cs: Remove duplicate ReadSLeb64 method, remove type aliases
- Transformer.cs: Use primary constructor for LabelType, improve error messages, simplify ReadMemorySection, throw on unsupported features
- WasmAssembly.cs: Use collection expressions, simplify Invoke method
- Lib.cs: Use expression-bodied Alloc/Realloc with meaningful errors, remove dead not_implemented_vec128_vec128, simplify WasmOpcodeAttribute