### PR TITLE
Add WebAssembly tail call opcode support

### DIFF
--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -726,20 +726,30 @@ public class Transformer
                     case WOp.NOP:
                         il.Emit(IlOp.Nop);
                         break;
+                    case WOp.RETURN_CALL:
                     case WOp.CALL:
+                    {
+                        var isTailCall = instr == WOp.RETURN_CALL;
                         var fcn = reader.ReadU32Leb();
                         var otherFun = ResolveMethod(moduleContext, fcn);
                         if (otherFun == null)
                             throw new InvalidOperationException($"Cannot resolve function at index {fcn}");
                         otherFun = moduleContext.MaybeWrap(otherFun);
 
+                        if (isTailCall)
+                            il.Emit(IlOp.Tail);
                         il.Emit(IlOp.Call, otherFun);
+                        if (isTailCall)
+                            il.Emit(IlOp.Ret);
 
                         ctx.PopType(otherFun.Parameters.Count);
-
                         ctx.PushType(otherFun.ReturnType);
                         break;
+                    }
+                    case WOp.RETURN_CALL_INDIRECT:
                     case WOp.CALL_INDIRECT:
+                    {
+                        var isTailCall = instr == WOp.RETURN_CALL_INDIRECT;
                         var typeidx = reader.ReadU32Leb();
                         var table = reader.ReadU32Leb();
                         if (table != 0)
@@ -764,10 +774,15 @@ public class Transformer
                         for (int i2 = 0; i2 < ftp.ParamCount; i2++)
                             il.Emit(IlOp.Ldloc, ctx.GetHelperVariable(ftp.ParamTypes[i2], i2 + 1));
                         var invoke = funct.GetMethod("Invoke");
+                        if (isTailCall)
+                            il.Emit(IlOp.Tail);
                         il.Emit(IlOp.Callvirt, def.MainModule.ImportReference(invoke));
+                        if (isTailCall)
+                            il.Emit(IlOp.Ret);
                         ctx.PopType((int) ftp.ParamCount);
                         ctx.PushType(ftp.ReturnType);
                         break;
+                    }
                     case WOp.BLOCK:
                         var blockType = reader.ReadU8();
                         var endLabel = il.Create(OpCodes.Nop);

--- a/Wasm2IL/WasmSpec/Instruction.cs
+++ b/Wasm2IL/WasmSpec/Instruction.cs
@@ -16,6 +16,8 @@ namespace Wasm
         RETURN = 0x0F,
         CALL = 0x10,
         CALL_INDIRECT = 0x11,
+        RETURN_CALL = 0x12,
+        RETURN_CALL_INDIRECT = 0x13,
         DROP = 0x1A,
         SELECT = 0x1B,
         SELECT_T = 0x1C,


### PR DESCRIPTION
Implement return_call (0x12) and return_call_indirect (0x13) instructions from the WebAssembly tail call proposal. These emit the IL Tail prefix followed by the call instruction and return, enabling proper tail call optimization in the generated IL.