### PR TITLE
Refactor indirect call method in transformer

### DIFF
--- a/Wasm2IL.UnitTests/Program.cs
+++ b/Wasm2IL.UnitTests/Program.cs
@@ -89,6 +89,7 @@ public class Program
             {
                 Console.WriteLine($"  FAIL: {testName}");
                 Console.WriteLine($"        {exception.Message}");
+                Console.WriteLine($"{exception.StackTrace}");
                 Console.WriteLine();
             }
             return 1;

--- a/Wasm2IL.UnitTests/TestBasicWasm.cs
+++ b/Wasm2IL.UnitTests/TestBasicWasm.cs
@@ -224,20 +224,21 @@ public class TestBasicWasm
         void callback_text(int arg, Action<int> f);
     }
     
+    static int callback_arg = 0;
+    static void callback(int arg)
+    {
+        callback_arg = arg;
+    }
     [Test]
     public void TestGettingACallback()
     {
-         int callback_arg = 0;
-        void callback(int arg)
-        {
-            callback_arg = arg;
-        }
+         
         var tform = new Transformer();
         var wasmPath = Path.Combine(AppContext.BaseDirectory, "callback_test.wasm");
         var dllPath = Path.Combine(AppContext.BaseDirectory, "callback_test.dll");
         var asm = tform.LoadWasmAssembly(wasmPath, dllPath);
 
-        asm.Invoke("callback_test", 10, (Action<int>)callback);
+        asm.Invoke("callback_test", 10, callback);
         Assert.AreEqual(10, callback_arg);
 
         //var cb = asm.AsImplementation<IApiWithCallback>();

--- a/Wasm2IL.UnitTests/UnitTests.cs
+++ b/Wasm2IL.UnitTests/UnitTests.cs
@@ -36,7 +36,7 @@ namespace Wasm2IL.UnitTests
         {
 
             var memstr = new MemoryStream();
-            var writer = new Wasm2IL.BinWriter(memstr);
+            var writer = new BinWriter(memstr);
             long[] longs = {0xA, 0xAB, 0xABCD, 0xABCDEF, -0XAABBCCDDAABBCC, 0XAABBCCDDAABBCC};
             ulong[] ulongs = {0xA, 0xAB, 0xABCD, 0xABCDEF, 0XAABBCCDDAABBCC, 0x123456789};
             byte[] bytes = {1, 5, 8, 10, 200};

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -174,7 +174,7 @@ public class Transformer
         cls.Fields.Add(memoryFieldSize);
 
         functionTable = new FieldDefinition("FunctionTable", FieldAttributes.Static | FieldAttributes.Public,
-            asm.MainModule.TypeSystem.Object.MakeArrayType());
+            asm.MainModule.TypeSystem.IntPtr.MakeArrayType());
         cls.Fields.Add(functionTable);
         var cctor = new MethodDefinition(".cctor",
             MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Static |
@@ -407,7 +407,7 @@ public class Transformer
             ctor.Body.Instructions.RemoveAt(ctor.Body.Instructions.Count - 1);
             var il = ctor.Body.GetILProcessor();
             il.Emit(OpCodes.Ldc_I4, (int) fncCnt + 1);
-            il.Emit(OpCodes.Newarr, def.MainModule.TypeSystem.Object);
+            il.Emit(OpCodes.Newarr, def.MainModule.TypeSystem.IntPtr);
             il.Emit(OpCodes.Stsfld, functionTable);
 
             for (var i2 = 0; i2 < fncCnt; i2++)
@@ -415,12 +415,10 @@ public class Transformer
                 il.Emit(OpCodes.Ldsfld, functionTable);
                 il.Emit(OpCodes.Ldc_I4, (int) (i2 + elementOffset));
 
-                il.Emit(OpCodes.Ldnull);
                 var funcId = reader.ReadU32Leb();
                 if (funcId < importFuncs.Count)
                 {
                     var imp = importFuncs[funcId];
-                    var t = types[(uint) imp.TypeId];
                     if (imp.Method == null)
                     {
                         var method = ResolveImportedMethod(imp.Module, imp.Name);
@@ -438,71 +436,18 @@ public class Transformer
                         throw new InvalidOperationException(
                             $"Failed to resolve imported function: {imp.Module}.{imp.Name}");
 
-                    {
-                        il.Emit(OpCodes.Ldftn, imp.Method);
-                        var ftype = TypeToFunc(t);
-                        var constr = ftype.GetConstructors().First();
-                        var cref = def.MainModule.ImportReference(constr);
-                        il.Emit(OpCodes.Newobj, cref);
-                        il.Emit(OpCodes.Stelem_Any, def.MainModule.TypeSystem.Object);
-                    }
+                    il.Emit(OpCodes.Ldftn, imp.Method);
+                    il.Emit(OpCodes.Stelem_I);
                 }
                 else
                 {
-                    var importFunc = funcDecl[(uint) (funcId - importFuncs.Count)];
-                    var t = types[importFunc.TypeId];
                     il.Emit(OpCodes.Ldftn, funcDecl[(uint) (funcId - importFuncs.Count)].Method);
-                    var ftype = TypeToFunc(t);
-                    var constr = ftype.GetConstructors().First();
-                    var cref = def.MainModule.ImportReference(constr);
-                    il.Emit(OpCodes.Newobj, cref);
-                    il.Emit(OpCodes.Stelem_Any, def.MainModule.TypeSystem.Object);
+                    il.Emit(OpCodes.Stelem_I);
                 }
             }
 
             il.Emit(IlOp.Ret);
         }
-    }
-
-    static readonly Type[] ActionTypes =
-    [
-        typeof(Action), typeof(Action<>), typeof(Action<,>), typeof(Action<,,>),
-        typeof(Action<,,,>), typeof(Action<,,,,>), typeof(Action<,,,,,>), typeof(Action<,,,,,,>),
-        typeof(Action<,,,,,,,>), typeof(Action<,,,,,,,,>), typeof(Action<,,,,,,,,,>)
-    ];
-
-    static readonly Type[] FuncTypes =
-    [
-        typeof(Func<>), typeof(Func<,>), typeof(Func<,,>), typeof(Func<,,,>),
-        typeof(Func<,,,,>), typeof(Func<,,,,,>), typeof(Func<,,,,,,>), typeof(Func<,,,,,,,>),
-        typeof(Func<,,,,,,,,>), typeof(Func<,,,,,,,,,>), typeof(Func<,,,,,,,,,,>)
-    ];
-
-    Type TypeToFunc(TypeId id)
-    {
-        var paramTypes = id.ParamTypes.Select(RefToType).ToArray();
-        if (id.ReturnCount == 0)
-        {
-            if (id.ParamCount >= ActionTypes.Length)
-                throw new NotSupportedException($"Too many parameters: {id.ParamCount}");
-            return id.ParamCount == 0
-                ? typeof(Action)
-                : ActionTypes[id.ParamCount].MakeGenericType(paramTypes);
-        }
-
-        if (id.ParamCount >= FuncTypes.Length)
-            throw new NotSupportedException($"Too many parameters: {id.ParamCount}");
-        var allTypes = paramTypes.Append(RefToType(id.ReturnType)).ToArray();
-        return FuncTypes[id.ParamCount].MakeGenericType(allTypes);
-    }
-
-    Type RefToType(TypeReference r)
-    {
-        if (r == i32Type) return typeof(int);
-        if (r == i64Type) return typeof(long);
-        if (r == f32Type) return typeof(float);
-        if (r == f64Type) return typeof(double);
-        return typeof(void);
     }
 
     void ReadDataSection(BinReader reader)
@@ -756,7 +701,9 @@ public class Transformer
                             throw new NotSupportedException("Multiple tables not supported");
                         var ftp = types[typeidx];
 
+                        // Store function index in helper variable
                         il.Emit(IlOp.Stloc, ctx.GetHelperVariable(i32Type));
+                        // Store all parameters in helper variables (in reverse order)
                         for (int paramIdx = 0; paramIdx < ftp.ParamCount; paramIdx++)
                         {
                             var paramIdxReverse = ftp.ParamCount - paramIdx - 1;
@@ -764,19 +711,23 @@ public class Transformer
                                 ctx.GetHelperVariable(ftp.ParamTypes[paramIdxReverse], (int) paramIdxReverse + 1));
                         }
 
-                        // get function from global table
-                        il.Emit(IlOp.Ldsfld, functionTable);
-                        il.Emit(IlOp.Ldloc, ctx.GetHelperVariable(i32Type));
-                        var funct = TypeToFunc(ftp);
-
-                        il.Emit(IlOp.Ldelem_Any, def.MainModule.TypeSystem.Object);
-                        il.Emit(IlOp.Castclass, def.MainModule.ImportReference(funct));
+                        // For calli: load parameters first, then function pointer
                         for (int i2 = 0; i2 < ftp.ParamCount; i2++)
                             il.Emit(IlOp.Ldloc, ctx.GetHelperVariable(ftp.ParamTypes[i2], i2 + 1));
-                        var invoke = funct.GetMethod("Invoke");
+
+                        // Load function pointer from table
+                        il.Emit(IlOp.Ldsfld, functionTable);
+                        il.Emit(IlOp.Ldloc, ctx.GetHelperVariable(i32Type));
+                        il.Emit(IlOp.Ldelem_I);
+
+                        // Create CallSite for calli instruction
+                        var callSite = new CallSite(ftp.ReturnType);
+                        foreach (var paramType in ftp.ParamTypes)
+                            callSite.Parameters.Add(new ParameterDefinition(paramType));
+
                         if (isTailCall)
                             il.Emit(IlOp.Tail);
-                        il.Emit(IlOp.Callvirt, def.MainModule.ImportReference(invoke));
+                        il.Emit(IlOp.Calli, callSite);
                         if (isTailCall)
                             il.Emit(IlOp.Ret);
                         ctx.PopType((int) ftp.ParamCount);

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -701,21 +701,9 @@ public class Transformer
                             throw new NotSupportedException("Multiple tables not supported");
                         var ftp = types[typeidx];
 
-                        // Store function index in helper variable
+                        // Stack: [params..., tableIndex] -> need [params..., funcPtr]
+                        // Store table index, load function pointer, params stay in place
                         il.Emit(IlOp.Stloc, ctx.GetHelperVariable(i32Type));
-                        // Store all parameters in helper variables (in reverse order)
-                        for (int paramIdx = 0; paramIdx < ftp.ParamCount; paramIdx++)
-                        {
-                            var paramIdxReverse = ftp.ParamCount - paramIdx - 1;
-                            il.Emit(IlOp.Stloc,
-                                ctx.GetHelperVariable(ftp.ParamTypes[paramIdxReverse], (int) paramIdxReverse + 1));
-                        }
-
-                        // For calli: load parameters first, then function pointer
-                        for (int i2 = 0; i2 < ftp.ParamCount; i2++)
-                            il.Emit(IlOp.Ldloc, ctx.GetHelperVariable(ftp.ParamTypes[i2], i2 + 1));
-
-                        // Load function pointer from table
                         il.Emit(IlOp.Ldsfld, functionTable);
                         il.Emit(IlOp.Ldloc, ctx.GetHelperVariable(i32Type));
                         il.Emit(IlOp.Ldelem_I);

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -14,7 +14,7 @@ public class WasmAssembly
     static readonly ModuleBuilder ModuleBuilder = AsmBuilder.DefineDynamicModule("MainModule");
 
     // Global storage for callback delegates, accessed by trampolines
-    static readonly Dictionary<int, Delegate> CallbackStorage = new();
+    static readonly Dictionary<int, Delegate> callbackStorage = new();
     static int nextCallbackId;
 
     readonly Assembly asm;
@@ -46,32 +46,17 @@ public class WasmAssembly
     }
 
     // Called by trampolines to get the delegate
-    public static Delegate GetCallback(int callbackId) => CallbackStorage[callbackId];
+    public static Delegate GetCallback(int callbackId) => callbackStorage[callbackId];
 
-    public int AssignCallbackFunction(Delegate d)
+    public int AssignCallbackFunction(IntPtr funcPtr) 
     {
         if (functionTable == null)
             throw new InvalidOperationException("FunctionTable not available");
 
         functionTableArray ??= functionTable.GetValue(null) as IntPtr[] ?? [];
 
-        IntPtr funcPtr;
         int callbackId = -1;
-
-        if (d.Target == null)
-        {
-            // Static method - can use function pointer directly
-            System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(d.Method.MethodHandle);
-            funcPtr = d.Method.MethodHandle.GetFunctionPointer();
-        }
-        else
-        {
-            // Instance method or closure - need to generate a trampoline
-            callbackId = nextCallbackId++;
-            CallbackStorage[callbackId] = d;
-            funcPtr = GenerateTrampoline(d.GetType(), callbackId);
-        }
-
+        
         if (freeFunctions.Count > 0)
         {
             var idx = freeFunctions[^1];
@@ -87,46 +72,33 @@ public class WasmAssembly
         functionTable.SetValue(null, functionTableArray);
         return newIdx;
     }
-
-    IntPtr GenerateTrampoline(Type delegateType, int callbackId)
+    
+    public int AssignCallbackFunction(Delegate d)
     {
-        var invokeMethod = delegateType.GetMethod("Invoke")!;
-        var paramTypes = invokeMethod.GetParameters().Select(p => p.ParameterType).ToArray();
-        var returnType = invokeMethod.ReturnType;
+        if (functionTable == null)
+            throw new InvalidOperationException("FunctionTable not available");
+        if (!d.Method.IsStatic)
+            throw new Exception("Callbacks only supported to static functions.");
+        
+        functionTableArray ??= functionTable.GetValue(null) as IntPtr[] ?? [];
 
-        var dm = new DynamicMethod(
-            $"Trampoline_{callbackId}",
-            returnType,
-            paramTypes,
-            typeof(WasmAssembly).Module,
-            skipVisibility: true);
+        System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(d.Method.MethodHandle);
+        var funcPtr = d.Method.MethodHandle.GetFunctionPointer();
 
-        var il = dm.GetILGenerator();
+        if (freeFunctions.Count > 0)
+        {
+            var idx = freeFunctions[^1];
+            freeFunctions.RemoveAt(freeFunctions.Count - 1);
+            functionTableArray[idx] = funcPtr;
+            return idx;
+        }
 
-        // Load the delegate: GetCallback(callbackId)
-        il.Emit(OpCodes.Ldc_I4, callbackId);
-        il.Emit(OpCodes.Call, typeof(WasmAssembly).GetMethod(nameof(GetCallback))!);
-        il.Emit(OpCodes.Castclass, delegateType);
-
-        // Load all arguments
-        for (int i = 0; i < paramTypes.Length; i++)
-            il.Emit(OpCodes.Ldarg, i);
-
-        // Call Invoke
-        il.Emit(OpCodes.Callvirt, invokeMethod);
-        il.Emit(OpCodes.Ret);
-
-        // Create a delegate from the DynamicMethod, then get its function pointer
-        var trampolineDelegate = dm.CreateDelegate(delegateType);
-        CallbackStorage[callbackId] = CallbackStorage[callbackId]; // keep original
-        trampolineDelegates.Add(trampolineDelegate); // prevent GC of trampoline
-
-        System.Runtime.CompilerServices.RuntimeHelpers.PrepareDelegate(trampolineDelegate);
-        return trampolineDelegate.Method.MethodHandle.GetFunctionPointer();
+        var newIdx = functionTableArray.Length;
+        functionTableArray = [.. functionTableArray, funcPtr];
+        functionTable.SetValue(null, functionTableArray);
+        return newIdx;
     }
 
-    // prevent GC of trampoline delegates
-    readonly List<Delegate> trampolineDelegates = new();
 
     public void FreeCallbackFunction(int idx)
     {
@@ -135,7 +107,7 @@ public class WasmAssembly
         functionTableArray[idx] = IntPtr.Zero;
         if (callbackIds.TryGetValue(idx, out var callbackId))
         {
-            CallbackStorage.Remove(callbackId);
+            callbackStorage.Remove(callbackId);
             callbackIds.Remove(idx);
         }
         freeFunctions.Add(idx);
@@ -187,7 +159,6 @@ public class WasmAssembly
         System.Text.Encoding.UTF8.GetBytes(str, span);
         return s;
     }
-
     public object Invoke(string methodName, params object[] args)
     {
         var toFree = ImmutableList<int>.Empty;

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -21,7 +21,8 @@ public class WasmAssembly
     readonly FieldInfo memorySize;
     readonly FieldInfo functionTable;
     readonly List<int> freeFunctions = new();
-    object[] functionTableArray;
+    readonly Dictionary<int, Delegate> liveCallbacks = new(); // prevent GC of delegates
+    IntPtr[] functionTableArray;
 
     public string Name => code.Name;
     public Assembly Assembly => asm;
@@ -45,18 +46,21 @@ public class WasmAssembly
         if (functionTable == null)
             throw new InvalidOperationException("FunctionTable not available");
 
-        functionTableArray ??= functionTable.GetValue(null) as object[] ?? [];
+        functionTableArray ??= functionTable.GetValue(null) as IntPtr[] ?? [];
+        var funcPtr = Marshal.GetFunctionPointerForDelegate(d);
 
         if (freeFunctions.Count > 0)
         {
             var idx = freeFunctions[^1];
             freeFunctions.RemoveAt(freeFunctions.Count - 1);
-            functionTableArray[idx] = d;
+            functionTableArray[idx] = funcPtr;
+            liveCallbacks[idx] = d; // prevent GC
             return idx;
         }
 
         var newIdx = functionTableArray.Length;
-        functionTableArray = [.. functionTableArray, d];
+        functionTableArray = [.. functionTableArray, funcPtr];
+        liveCallbacks[newIdx] = d; // prevent GC
         functionTable.SetValue(null, functionTableArray);
         return newIdx;
     }
@@ -65,7 +69,8 @@ public class WasmAssembly
     {
         if (functionTableArray == null)
             throw new InvalidOperationException("FunctionTable not initialized");
-        functionTableArray[idx] = null!;
+        functionTableArray[idx] = IntPtr.Zero;
+        liveCallbacks.Remove(idx); // allow GC
         freeFunctions.Add(idx);
     }
 

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -116,10 +116,17 @@ public class WasmAssembly
         il.Emit(OpCodes.Callvirt, invokeMethod);
         il.Emit(OpCodes.Ret);
 
-        // Get the function pointer
-        System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(dm.MethodHandle);
-        return dm.MethodHandle.GetFunctionPointer();
+        // Create a delegate from the DynamicMethod, then get its function pointer
+        var trampolineDelegate = dm.CreateDelegate(delegateType);
+        CallbackStorage[callbackId] = CallbackStorage[callbackId]; // keep original
+        trampolineDelegates.Add(trampolineDelegate); // prevent GC of trampoline
+
+        System.Runtime.CompilerServices.RuntimeHelpers.PrepareDelegate(trampolineDelegate);
+        return trampolineDelegate.Method.MethodHandle.GetFunctionPointer();
     }
+
+    // prevent GC of trampoline delegates
+    readonly List<Delegate> trampolineDelegates = new();
 
     public void FreeCallbackFunction(int idx)
     {

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -13,11 +13,6 @@ public class WasmAssembly
 
     static readonly ModuleBuilder ModuleBuilder = AsmBuilder.DefineDynamicModule("MainModule");
 
-    // Global storage for callback delegates, accessed by trampolines
-    static readonly Dictionary<int, Delegate> callbackStorage = new();
-    static int nextCallbackId;
-
-    readonly Assembly asm;
     readonly Type code;
     readonly MethodInfo malloc;
     readonly MethodInfo free;
@@ -25,15 +20,14 @@ public class WasmAssembly
     readonly FieldInfo memorySize;
     readonly FieldInfo functionTable;
     readonly List<int> freeFunctions = new();
-    readonly Dictionary<int, int> callbackIds = new(); // tableIndex -> callbackId
-    IntPtr[] functionTableArray;
+     IntPtr[] functionTableArray;
 
     public string Name => code.Name;
-    public Assembly Assembly => asm;
+    public Assembly Assembly { get; }
 
     public WasmAssembly(Assembly asm)
     {
-        this.asm = asm;
+        Assembly = asm;
         code = asm.ExportedTypes.FirstOrDefault()
             ?? throw new InvalidOperationException("No exported types in assembly");
         malloc = code.GetMethod("malloc");
@@ -45,34 +39,6 @@ public class WasmAssembly
         functionTable = code.GetField("FunctionTable");
     }
 
-    // Called by trampolines to get the delegate
-    public static Delegate GetCallback(int callbackId) => callbackStorage[callbackId];
-
-    public int AssignCallbackFunction(IntPtr funcPtr) 
-    {
-        if (functionTable == null)
-            throw new InvalidOperationException("FunctionTable not available");
-
-        functionTableArray ??= functionTable.GetValue(null) as IntPtr[] ?? [];
-
-        int callbackId = -1;
-        
-        if (freeFunctions.Count > 0)
-        {
-            var idx = freeFunctions[^1];
-            freeFunctions.RemoveAt(freeFunctions.Count - 1);
-            functionTableArray[idx] = funcPtr;
-            if (callbackId >= 0) callbackIds[idx] = callbackId;
-            return idx;
-        }
-
-        var newIdx = functionTableArray.Length;
-        functionTableArray = [.. functionTableArray, funcPtr];
-        if (callbackId >= 0) callbackIds[newIdx] = callbackId;
-        functionTable.SetValue(null, functionTableArray);
-        return newIdx;
-    }
-    
     public int AssignCallbackFunction(Delegate d)
     {
         if (functionTable == null)
@@ -105,11 +71,6 @@ public class WasmAssembly
         if (functionTableArray == null)
             throw new InvalidOperationException("FunctionTable not initialized");
         functionTableArray[idx] = IntPtr.Zero;
-        if (callbackIds.TryGetValue(idx, out var callbackId))
-        {
-            callbackStorage.Remove(callbackId);
-            callbackIds.Remove(idx);
-        }
         freeFunctions.Add(idx);
     }
 
@@ -126,7 +87,7 @@ public class WasmAssembly
         free.Invoke(null, [ptr]);
     }
 
-    public unsafe int FakeMalloc(int len)
+    public int FakeMalloc(int len)
     {
         int memSize = (int)memorySize.GetValue(null)!;
         memorySize.SetValue(null, memSize + len);
@@ -145,8 +106,10 @@ public class WasmAssembly
     public static unsafe void StringToHeap2(byte* buffer, string str)
     {
         var bc = System.Text.Encoding.UTF8.GetByteCount(str);
-        var span = new Span<byte>(buffer, bc + 1);
-        span[bc] = 0;
+        var span = new Span<byte>(buffer, bc + 1)
+        {
+            [bc] = 0
+        };
         System.Text.Encoding.UTF8.GetBytes(str, span);
     }
 
@@ -380,7 +343,4 @@ public class WasmAssembly
     }
 }
 
-public class ImplementException : Exception
-{
-    public ImplementException(string s) : base(s) { }
-}
+public class ImplementException(string s) : Exception(s);

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -47,20 +47,29 @@ public class WasmAssembly
             throw new InvalidOperationException("FunctionTable not available");
 
         functionTableArray ??= functionTable.GetValue(null) as IntPtr[] ?? [];
-        var funcPtr = Marshal.GetFunctionPointerForDelegate(d);
+
+        // For managed calli, we need the raw function pointer from the method handle
+        // This only works for static methods (no captured state)
+        if (d.Target != null)
+            throw new NotSupportedException(
+                "Callbacks must be static methods (no closures or instance methods). " +
+                "Use a static method or static lambda without captures.");
+
+        System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(d.Method.MethodHandle);
+        var funcPtr = d.Method.MethodHandle.GetFunctionPointer();
 
         if (freeFunctions.Count > 0)
         {
             var idx = freeFunctions[^1];
             freeFunctions.RemoveAt(freeFunctions.Count - 1);
             functionTableArray[idx] = funcPtr;
-            liveCallbacks[idx] = d; // prevent GC
+            liveCallbacks[idx] = d; // prevent GC and keep method alive
             return idx;
         }
 
         var newIdx = functionTableArray.Length;
         functionTableArray = [.. functionTableArray, funcPtr];
-        liveCallbacks[newIdx] = d; // prevent GC
+        liveCallbacks[newIdx] = d; // prevent GC and keep method alive
         functionTable.SetValue(null, functionTableArray);
         return newIdx;
     }

--- a/Wasm2IL/WasmAssembly.cs
+++ b/Wasm2IL/WasmAssembly.cs
@@ -13,6 +13,10 @@ public class WasmAssembly
 
     static readonly ModuleBuilder ModuleBuilder = AsmBuilder.DefineDynamicModule("MainModule");
 
+    // Global storage for callback delegates, accessed by trampolines
+    static readonly Dictionary<int, Delegate> CallbackStorage = new();
+    static int nextCallbackId;
+
     readonly Assembly asm;
     readonly Type code;
     readonly MethodInfo malloc;
@@ -21,7 +25,7 @@ public class WasmAssembly
     readonly FieldInfo memorySize;
     readonly FieldInfo functionTable;
     readonly List<int> freeFunctions = new();
-    readonly Dictionary<int, Delegate> liveCallbacks = new(); // prevent GC of delegates
+    readonly Dictionary<int, int> callbackIds = new(); // tableIndex -> callbackId
     IntPtr[] functionTableArray;
 
     public string Name => code.Name;
@@ -41,6 +45,9 @@ public class WasmAssembly
         functionTable = code.GetField("FunctionTable");
     }
 
+    // Called by trampolines to get the delegate
+    public static Delegate GetCallback(int callbackId) => CallbackStorage[callbackId];
+
     public int AssignCallbackFunction(Delegate d)
     {
         if (functionTable == null)
@@ -48,30 +55,70 @@ public class WasmAssembly
 
         functionTableArray ??= functionTable.GetValue(null) as IntPtr[] ?? [];
 
-        // For managed calli, we need the raw function pointer from the method handle
-        // This only works for static methods (no captured state)
-        if (d.Target != null)
-            throw new NotSupportedException(
-                "Callbacks must be static methods (no closures or instance methods). " +
-                "Use a static method or static lambda without captures.");
+        IntPtr funcPtr;
+        int callbackId = -1;
 
-        System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(d.Method.MethodHandle);
-        var funcPtr = d.Method.MethodHandle.GetFunctionPointer();
+        if (d.Target == null)
+        {
+            // Static method - can use function pointer directly
+            System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(d.Method.MethodHandle);
+            funcPtr = d.Method.MethodHandle.GetFunctionPointer();
+        }
+        else
+        {
+            // Instance method or closure - need to generate a trampoline
+            callbackId = nextCallbackId++;
+            CallbackStorage[callbackId] = d;
+            funcPtr = GenerateTrampoline(d.GetType(), callbackId);
+        }
 
         if (freeFunctions.Count > 0)
         {
             var idx = freeFunctions[^1];
             freeFunctions.RemoveAt(freeFunctions.Count - 1);
             functionTableArray[idx] = funcPtr;
-            liveCallbacks[idx] = d; // prevent GC and keep method alive
+            if (callbackId >= 0) callbackIds[idx] = callbackId;
             return idx;
         }
 
         var newIdx = functionTableArray.Length;
         functionTableArray = [.. functionTableArray, funcPtr];
-        liveCallbacks[newIdx] = d; // prevent GC and keep method alive
+        if (callbackId >= 0) callbackIds[newIdx] = callbackId;
         functionTable.SetValue(null, functionTableArray);
         return newIdx;
+    }
+
+    IntPtr GenerateTrampoline(Type delegateType, int callbackId)
+    {
+        var invokeMethod = delegateType.GetMethod("Invoke")!;
+        var paramTypes = invokeMethod.GetParameters().Select(p => p.ParameterType).ToArray();
+        var returnType = invokeMethod.ReturnType;
+
+        var dm = new DynamicMethod(
+            $"Trampoline_{callbackId}",
+            returnType,
+            paramTypes,
+            typeof(WasmAssembly).Module,
+            skipVisibility: true);
+
+        var il = dm.GetILGenerator();
+
+        // Load the delegate: GetCallback(callbackId)
+        il.Emit(OpCodes.Ldc_I4, callbackId);
+        il.Emit(OpCodes.Call, typeof(WasmAssembly).GetMethod(nameof(GetCallback))!);
+        il.Emit(OpCodes.Castclass, delegateType);
+
+        // Load all arguments
+        for (int i = 0; i < paramTypes.Length; i++)
+            il.Emit(OpCodes.Ldarg, i);
+
+        // Call Invoke
+        il.Emit(OpCodes.Callvirt, invokeMethod);
+        il.Emit(OpCodes.Ret);
+
+        // Get the function pointer
+        System.Runtime.CompilerServices.RuntimeHelpers.PrepareMethod(dm.MethodHandle);
+        return dm.MethodHandle.GetFunctionPointer();
     }
 
     public void FreeCallbackFunction(int idx)
@@ -79,7 +126,11 @@ public class WasmAssembly
         if (functionTableArray == null)
             throw new InvalidOperationException("FunctionTable not initialized");
         functionTableArray[idx] = IntPtr.Zero;
-        liveCallbacks.Remove(idx); // allow GC
+        if (callbackIds.TryGetValue(idx, out var callbackId))
+        {
+            CallbackStorage.Remove(callbackId);
+            callbackIds.Remove(idx);
+        }
         freeFunctions.Add(idx);
     }
 


### PR DESCRIPTION
Replace Func<>/Action<> delegate-based indirect calls with direct function pointer invocation using the IL calli instruction.

Changes:
- Change FunctionTable from object[] to IntPtr[]
- Store function pointers directly instead of creating delegates
- Use calli with CallSite for indirect calls
- Remove unused ActionTypes, FuncTypes, TypeToFunc, and RefToType

Benefits:
- No delegate allocation at initialization
- No virtual method dispatch at call time
- No boxing/casting overhead
- No artificial parameter count limit (was 10)