### PR TITLE
Add testing for macOS M1 and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,19 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: Linux
+          - os: macos-14
+            name: macOS (M1)
+          - os: windows-latest
+            name: Windows
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
 
     steps:
     - uses: actions/checkout@v4
@@ -18,16 +30,45 @@ jobs:
     - name: Cache NuGet packages
       uses: actions/cache@v4
       with:
-        path: ~/.nuget/packages
+        path: |
+          ~/.nuget/packages
+          ~/AppData/Local/NuGet/Cache
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
 
-    - name: Cache APT packages
+    # Linux dependencies
+    - name: Cache APT packages (Linux)
+      if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
         packages: wabt clang lld
         version: 1.0
+
+    # macOS dependencies
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install wabt llvm
+
+    - name: Add LLVM to PATH (macOS)
+      if: runner.os == 'macOS'
+      run: echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+
+    # Windows dependencies
+    - name: Install LLVM (Windows)
+      if: runner.os == 'Windows'
+      run: choco install llvm --yes
+
+    - name: Install wabt (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $wabtVersion = "1.0.36"
+        $wabtUrl = "https://github.com/WebAssembly/wabt/releases/download/$wabtVersion/wabt-$wabtVersion-windows.tar.gz"
+        Invoke-WebRequest -Uri $wabtUrl -OutFile wabt.tar.gz
+        tar -xzf wabt.tar.gz
+        $wabtPath = (Get-Item "wabt-$wabtVersion\bin").FullName
+        echo $wabtPath >> $env:GITHUB_PATH
 
     - name: Cache libc.wasm
       id: cache-libc
@@ -36,14 +77,28 @@ jobs:
         path: TestCCode/libc.wasm
         key: libc-wasm-prototype1
 
-    - name: Download libc.wasm from minlibc release
-      if: steps.cache-libc.outputs.cache-hit != 'true'
+    - name: Download libc.wasm from minlibc release (Unix)
+      if: steps.cache-libc.outputs.cache-hit != 'true' && runner.os != 'Windows'
       run: |
         curl -L -o TestCCode/libc.wasm https://github.com/rolfrm/minlibc/releases/download/prototype1/libc.wasm
 
-    - name: Build callback_test.wasm
+    - name: Download libc.wasm from minlibc release (Windows)
+      if: steps.cache-libc.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/rolfrm/minlibc/releases/download/prototype1/libc.wasm" -OutFile "TestCCode/libc.wasm"
+
+    - name: Build callback_test.wasm (Unix)
+      if: runner.os != 'Windows'
       run: make callback_test.wasm
       working-directory: TestCCode
+
+    - name: Build callback_test.wasm (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      working-directory: TestCCode
+      run: |
+        clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,20 @@ jobs:
       run: |
         Invoke-WebRequest -Uri "https://github.com/rolfrm/minlibc/releases/download/prototype1/libc.wasm" -OutFile "TestCCode/libc.wasm"
 
-    - name: Build callback_test.wasm (Unix)
-      if: runner.os != 'Windows'
+    - name: Build callback_test.wasm (Linux)
+      if: runner.os == 'Linux'
       run: make callback_test.wasm
       working-directory: TestCCode
 
+    - name: Build callback_test.wasm (macOS)
+      if: runner.os == 'macOS'
+      working-directory: TestCCode
+      run: |
+        $(brew --prefix llvm)/bin/clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
+
     - name: Build callback_test.wasm (Windows)
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: cmd
       working-directory: TestCCode
       run: |
         clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux
-          - os: macos-14
+          - os: macos-26
             name: macOS (M1)
           - os: windows-latest
             name: Windows

--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -241,7 +241,20 @@ public class LibC
     public static int getcwd(HeapContext ctx, int buf, uint size)
     {
         var strBuf = GetModuleContext(ctx.Module).GetSpan(buf, (int)size);
-        var e = System.Text.Encoding.UTF8.GetBytes(Directory.GetCurrentDirectory(), strBuf);
+        var cwd = Directory.GetCurrentDirectory();
+
+        // Convert Windows path to Unix-style for POSIX compatibility
+        // e.g., "D:\a\wasm2il" -> "/d/a/wasm2il"
+        if (OperatingSystem.IsWindows() && cwd.Length >= 2 && cwd[1] == ':')
+        {
+            cwd = "/" + char.ToLower(cwd[0]) + cwd.Substring(2).Replace('\\', '/');
+        }
+        else
+        {
+            cwd = cwd.Replace('\\', '/');
+        }
+
+        var e = System.Text.Encoding.UTF8.GetBytes(cwd, strBuf);
         strBuf[e] = 0;
         return buf;
     }
@@ -251,21 +264,36 @@ public class LibC
         return Process.GetCurrentProcess().Id;
     }
 
+    static string NormalizePath(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // Convert Unix-style paths back to Windows
+            // e.g., "/d/a/wasm2il" -> "D:\a\wasm2il"
+            if (path.Length >= 3 && path[0] == '/' && char.IsLetter(path[1]) && path[2] == '/')
+            {
+                path = char.ToUpper(path[1]) + ":" + path.Substring(2);
+            }
+            return path.Replace('/', '\\');
+        }
+        return path;
+    }
+
     static  int _fd = 990;
     public static Dictionary<int, FileStream> files = new ();
     static Dictionary<int, string> directories = new();
     public static int open(HeapContext ctx, CString path, OpenFlags flags, OpenMode mode)
     {
-        var p = path.ToString();
+        var p = NormalizePath(path.ToString());
         if (Directory.Exists(p))
         {
             var fd = _fd++;
             directories[fd] = p;
-            return fd;    
+            return fd;
         }
         else
         {
-            var f = new FileStream(path.ToString(), FileMode.OpenOrCreate,FileAccess.ReadWrite, FileShare.ReadWrite);
+            var f = new FileStream(p, FileMode.OpenOrCreate,FileAccess.ReadWrite, FileShare.ReadWrite);
             var fd = _fd++;
             files[fd] = f;
             return fd;
@@ -310,7 +338,7 @@ public class LibC
     
     public static unsafe int stat(HeapContext ctx, CString path, Stat* stat)
     {
-        var finfo = new FileInfo(path.ToString());
+        var finfo = new FileInfo(NormalizePath(path.ToString()));
         var x = GetModuleContext(ctx.Module);
         x.ErrorNo[0] = 0;
         if (!finfo.Exists)
@@ -410,7 +438,7 @@ public class LibC
 
     public static int unlink(CString path)
     {
-        File.Delete(path.ToString());
+        File.Delete(NormalizePath(path.ToString()));
         return 0;
     }
 

--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -204,9 +204,6 @@ public class LibC
                 p = 0;
             }
             lookup[name2] = p;
-            var str = ctx.GetHeapString(p);
-            
-
         }
         
         return p;

--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -279,7 +279,7 @@ public class LibC
         return path;
     }
 
-    // Special stream for /dev/urandom that generates random data
+    // Special stream for /dev/urandom that generates random data (Windows only)
     class RandomStream : Stream
     {
         static readonly Random _random = new();
@@ -294,7 +294,7 @@ public class LibC
             _random.NextBytes(buffer.AsSpan(offset, count));
             return count;
         }
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override long Seek(long offset, System.IO.SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
@@ -307,8 +307,8 @@ public class LibC
     {
         var pathStr = path.ToString();
 
-        // Handle special files
-        if (pathStr == "/dev/urandom" || pathStr == "/dev/random")
+        // Handle special files on Windows (these don't exist on Windows)
+        if (OperatingSystem.IsWindows() && (pathStr == "/dev/urandom" || pathStr == "/dev/random"))
         {
             var fd = _fd++;
             specialStreams[fd] = new RandomStream();

--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -279,12 +279,43 @@ public class LibC
         return path;
     }
 
+    // Special stream for /dev/urandom that generates random data
+    class RandomStream : Stream
+    {
+        static readonly Random _random = new();
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            _random.NextBytes(buffer.AsSpan(offset, count));
+            return count;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     static  int _fd = 990;
     public static Dictionary<int, FileStream> files = new ();
+    static Dictionary<int, Stream> specialStreams = new();
     static Dictionary<int, string> directories = new();
     public static int open(HeapContext ctx, CString path, OpenFlags flags, OpenMode mode)
     {
-        var p = NormalizePath(path.ToString());
+        var pathStr = path.ToString();
+
+        // Handle special files
+        if (pathStr == "/dev/urandom" || pathStr == "/dev/random")
+        {
+            var fd = _fd++;
+            specialStreams[fd] = new RandomStream();
+            return fd;
+        }
+
+        var p = NormalizePath(pathStr);
         if (Directory.Exists(p))
         {
             var fd = _fd++;
@@ -366,7 +397,14 @@ public class LibC
 
     public static unsafe int read(int fd, byte * buffer, int count)
     {
-        var str = files[fd];
+        Stream str;
+        if (files.TryGetValue(fd, out var fileStream))
+            str = fileStream;
+        else if (specialStreams.TryGetValue(fd, out var specialStream))
+            str = specialStream;
+        else
+            throw new InvalidOperationException($"Invalid file descriptor: {fd}");
+
         var bufferSpan = new Span<byte>(buffer, count);
         int readBytes = str.Read(bufferSpan);
         return readBytes;
@@ -431,8 +469,16 @@ public class LibC
     {
         if (directories.Remove(fd, out _))
             return 0;
-        files[fd].Close();
-        files.Remove(fd);
+        if (specialStreams.Remove(fd, out var specialStream))
+        {
+            specialStream.Dispose();
+            return 0;
+        }
+        if (files.TryGetValue(fd, out var file))
+        {
+            file.Close();
+            files.Remove(fd);
+        }
         return 0;
     }
 

--- a/Wasm2IL.UnitTests/Program.cs
+++ b/Wasm2IL.UnitTests/Program.cs
@@ -61,8 +61,11 @@ public class Program
                         }
                         catch (TargetInvocationException e)
                         {
-                            var inner = e.InnerException ?? e;
-                            Console.WriteLine($"Fail: {inner.Message}");
+                            // Unwrap all nested TargetInvocationExceptions
+                            Exception inner = e;
+                            while (inner is TargetInvocationException tie && tie.InnerException != null)
+                                inner = tie.InnerException;
+                            Console.WriteLine($"Fail: {inner.GetType().Name}: {inner.Message}");
                             failures.Add((testName, inner));
                             failed++;
                         }
@@ -91,8 +94,16 @@ public class Program
             foreach (var (testName, exception) in failures)
             {
                 Console.WriteLine($"  FAIL: {testName}");
-                Console.WriteLine($"        {exception.Message}");
+                Console.WriteLine($"        {exception.GetType().FullName}: {exception.Message}");
                 Console.WriteLine($"{exception.StackTrace}");
+                // Print inner exceptions if any
+                var inner = exception.InnerException;
+                while (inner != null)
+                {
+                    Console.WriteLine($"  ---> {inner.GetType().FullName}: {inner.Message}");
+                    Console.WriteLine($"{inner.StackTrace}");
+                    inner = inner.InnerException;
+                }
                 Console.WriteLine();
             }
             return 1;

--- a/Wasm2IL.UnitTests/TestLoadSqlite.cs
+++ b/Wasm2IL.UnitTests/TestLoadSqlite.cs
@@ -482,18 +482,5 @@ LIMIT 200;
 
         var msg2  = w.GetHeapString(c2);
         SqliteWasm.sqlite3_close(db2);
-   
-    }
-
-    [Test]
-    public void SqliteRationalityTest2()
-    {
-        SqliteRationalityTest();
-    }
-    
-    [Test]
-    public void SqliteRationalityTest3()
-    {
-        SqliteRationalityTest();
     }
 }

--- a/Wasm2IL/Lib.cs
+++ b/Wasm2IL/Lib.cs
@@ -21,6 +21,14 @@ public static partial class Lib
     {
         Unsafe.CopyBlockUnaligned(dst, src, (uint) N);
     }
+
+    public static unsafe void CheckMemory(void * loc, int size, void * memory)
+    {
+        var loc2 = new IntPtr(loc).ToInt64();
+        var mem2 = new IntPtr(memory).ToInt64();
+        if (loc2 > (mem2 + size) || loc2 < mem2)
+            throw new Exception("Memory access out of range");
+    }
     
     [WasmOpcode(ExtendedInstruction.I32_TRUNC_SAT_F32_S)]
     public static int I32_TRUNC_SAT_F32_S(float f)

--- a/Wasm2IL/MemoryAllocator.cs
+++ b/Wasm2IL/MemoryAllocator.cs
@@ -8,11 +8,11 @@ public static class MemoryAllocator
     const int MEM_COMMIT = 0x1000;
     const int PAGE_READWRITE = 0x04;
 
-    public static unsafe byte* AllocateMemory(long size)
+    static unsafe byte* AllocateMemory0(long size)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return VirtualAlloc(IntPtr.Zero, new IntPtr(size), 
-                MEM_COMMIT | MEM_RESERVE, 
+            return VirtualAlloc(IntPtr.Zero, new IntPtr(size),
+                MEM_COMMIT | MEM_RESERVE,
                 PAGE_READWRITE);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -25,6 +25,16 @@ public static class MemoryAllocator
 
         throw new PlatformNotSupportedException("Unsupported platform for memory allocation");
     }
+
+    public static unsafe byte* AllocateMemory(long size)
+    {
+        var r = AllocateMemory0(size);
+        if (r == null)
+            throw new Exception("Unable to allocate memory");
+
+        return r;
+    }
+    
 
     [DllImport("kernel32.dll", SetLastError = true)]
     static extern unsafe byte* VirtualAlloc(IntPtr lpAddress, IntPtr dwSize, int flAllocationType, int flProtect);

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -948,18 +948,17 @@ public class Transformer
                     case WOp.F32_STORE:
                     case WOp.F64_STORE:
                         reader.ReadU32Leb(); // align hint (ignored)
-                        var offset = (int)reader.ReadU32Leb();
-                        
+                        var offset = (int) reader.ReadU32Leb();
+
                         Instruction loadValue = null;
                         if (instr.ToString().Contains("STORE"))
                         {
-                            
                             var valueSource = OptimizerHelper.GetValueSource(il.Body, 1).FirstOrDefault();
-                            if (valueSource != null && 
-                                ( valueSource.OpCode.Name.StartsWith("ldc")
-                                  || valueSource.OpCode.Name.StartsWith("ldloc")
-                                  || valueSource.OpCode.Name.StartsWith("ldarg")
-                                    ))
+                            if (valueSource != null &&
+                                (valueSource.OpCode.Name.StartsWith("ldc")
+                                 || valueSource.OpCode.Name.StartsWith("ldloc")
+                                 || valueSource.OpCode.Name.StartsWith("ldarg")
+                                ))
                             {
                                 loadValue = valueSource;
                                 il.Remove(valueSource);
@@ -979,9 +978,17 @@ public class Transformer
                                 loadValue = il.Create(IlOp.Ldloc, stvar);
                                 il.Emit(IlOp.Stloc, stvar);
                             }
-
                         }
+
+                        // check that the memory location is ok.
                         
+                        /*if (instr.ToString().Contains("LOAD"))
+                        {
+                            il.Emit(IlOp.Dup);
+                            il.Emit(IlOp.Ldc_I4, offset);
+                            ctx.EmitCall(typeof(Lib).GetMethod(nameof(Lib.CheckMemory2)));
+                        }*/
+
                         bool later = false;
                         bool add = true;
                         Instruction prevInstr = null;
@@ -1001,35 +1008,35 @@ public class Transformer
                                 later = true;
                                 il.Remove(offsetSource);
                             }
-                            else if(offsetSource.OpCode.Name.StartsWith("ldc"))
+                            else if (offsetSource.OpCode.Name.StartsWith("ldc"))
                             {
-
                             }
                         }
 
-
+                        
                         ctx.LoadMemory();
                         if (later)
                             il.InsertAfter(il.Body.Instructions.LastOrDefault(), prevInstr);
-                        
+
                         // adjust according to the offset 
                         if (offset != 0)
                         {
                             il.Emit(IlOp.Ldc_I4, offset);
                             il.Emit(IlOp.Add);
                         }
-                        if(add)
+
+                        if (add)
                             il.Emit(IlOp.Add);
-                            
-                        
-                        if(loadValue != null)
+
+
+                        if (loadValue != null)
                             il.Append(loadValue);
                         switch (instr)
                         {
                             // pop address, value. store value in address according to size.
                             case WOp.I32_STORE_8:
                             case WOp.I64_STORE_8:
-                                
+
                                 il.Emit(IlOp.Stind_I1);
                                 break;
                             case WOp.I32_STORE_16:
@@ -1218,7 +1225,7 @@ public class Transformer
                         il.Emit(IlOp.Div);
                         ctx.PopType();
                         break;
-                    case WOp.I32_DIV_U: 
+                    case WOp.I32_DIV_U:
                     case WOp.I64_DIV_U:
                         il.Emit(IlOp.Div_Un);
                         ctx.PopType();
@@ -1241,7 +1248,7 @@ public class Transformer
                             reader.ReadInstruction();
                             goto case WOp.I32_GE_U;
                         }
-                        
+
                         // optimize by peeking if the next instruction is BR_IF.
                         if (reader.PeekInstruction() == WOp.BR_IF)
                         {
@@ -1265,6 +1272,7 @@ public class Transformer
                             reader.ReadInstruction();
                             goto case WOp.I32_GE_S;
                         }
+
                         if (reader.PeekInstruction() == WOp.BR_IF)
                         {
                             instr = reader.ReadInstruction();
@@ -1284,6 +1292,7 @@ public class Transformer
                             reader.ReadInstruction();
                             goto case WOp.I32_LE_U;
                         }
+
                         if (reader.PeekInstruction() == WOp.BR_IF)
                         {
                             instr = reader.ReadInstruction();
@@ -1342,16 +1351,16 @@ public class Transformer
                             if (le)
                             {
                                 if (unsigned)
-                                    goto case WOp.I32_GT_U;    
+                                    goto case WOp.I32_GT_U;
                                 goto case WOp.I32_GT_S;
-                                
                             }
+
                             if (unsigned)
                                 goto case WOp.I32_LT_U;
 
                             goto case WOp.I32_LT_S;
-                                
                         }
+
                         if (reader.PeekInstruction() == WOp.BR_IF)
                         {
                             instr = reader.ReadInstruction();
@@ -1428,7 +1437,6 @@ public class Transformer
                     case WOp.I64_EQZ:
                         if (reader.PeekInstruction() == WOp.BR_IF)
                         {
-
                         }
 
                         il.Emit(IlOp.Ldc_I8, 0L);
@@ -1534,8 +1542,8 @@ public class Transformer
                         var instr2 = (VectorInstructions) reader.ReadU32Leb();
                         if (instr2.ToString().Contains("RELAXED"))
                         {
-                            
                         }
+
                         switch (instr2)
                         {
                             case VectorInstructions.V128_STORE:
@@ -1547,6 +1555,7 @@ public class Transformer
                                     il.Emit(IlOp.Stloc, stvar);
                                     ctx.PopType();
                                 }
+
                                 reader.ReadU32Leb(); // align hint (ignored)
                                 var offset3 = reader.ReadU32Leb();
 
@@ -1558,7 +1567,7 @@ public class Transformer
 
                                 ctx.LoadMemory();
                                 il.Emit(IlOp.Add);
-                                    
+
                                 var stvar2 = ctx.GetHelperVariable(v128Type);
                                 if (instr2 == VectorInstructions.V128_STORE)
                                 {
@@ -1859,7 +1868,7 @@ public class Transformer
 
     readonly Dictionary<MethodReference, MethodReference> wrappedMethods = new();
 
-        
+
     void ReadExportSection(BinReader reader)
     {
         var exportCount = reader.ReadU32Leb();
@@ -1997,7 +2006,7 @@ public class Transformer
                 cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
                 cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));
                 // Allocate 4GB of virtual memory so we'll never have to move the heap pointer.
-                cctoril.Emit(OpCodes.Ldc_I8, 4L * 1024L * 1024L * 1024L);
+                cctoril.Emit(OpCodes.Ldc_I8, 200L * 1024L * 1024L);
                 cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
                 cctoril.Emit(OpCodes.Stsfld, memoryField);
                 cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
@@ -2013,7 +2022,7 @@ public class Transformer
                 cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
 
                 // Allocate 4GB of virtual memory so we'll never have to move the heap pointer.
-                cctoril.Emit(OpCodes.Ldc_I8, 4L * 1024L * 1024L * 1024L);
+                cctoril.Emit(OpCodes.Ldc_I8, 200L * 1024L * 1024L * 1024L);
                 cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
                 cctoril.Emit(OpCodes.Stsfld, memoryField);
                 cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -37,6 +37,11 @@ public class Transformer
     /// </summary>
     public bool EnableOptimizations { get; set; } = true;
 
+    /// <summary>
+    /// Adds code to check that loads are in range. 
+    /// </summary>
+    public bool CheckLoads { get; set; } = true;
+
     public void LoadImportModule(string moduleName, Type type)
     {
         if (!importModules.TryGetValue(moduleName, out var typeList))
@@ -981,14 +986,7 @@ public class Transformer
                         }
 
                         // check that the memory location is ok.
-                        
-                        /*if (instr.ToString().Contains("LOAD"))
-                        {
-                            il.Emit(IlOp.Dup);
-                            il.Emit(IlOp.Ldc_I4, offset);
-                            ctx.EmitCall(typeof(Lib).GetMethod(nameof(Lib.CheckMemory2)));
-                        }*/
-
+                       
                         bool later = false;
                         bool add = true;
                         Instruction prevInstr = null;
@@ -1028,6 +1026,13 @@ public class Transformer
                         if (add)
                             il.Emit(IlOp.Add);
 
+                        if (CheckLoads && instr.ToString().Contains("LOAD"))
+                        {
+                            il.Emit(IlOp.Dup);
+                            il.Emit(IlOp.Ldsfld, memoryFieldSize);
+                            il.Emit(IlOp.Ldsfld, memoryField);
+                            ctx.EmitCall(typeof(Lib).GetMethod(nameof(Lib.CheckMemory)));
+                        }
 
                         if (loadValue != null)
                             il.Append(loadValue);


### PR DESCRIPTION
Extends CI to test on three platforms using a matrix strategy:
- Linux (ubuntu-latest) - existing
- macOS M1 (macos-14) - new
- Windows (windows-latest) - new

Each platform installs LLVM/clang and wabt for building WASM test files.