### PR TITLE
Fix WebAssembly compilation error in callback test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,7 @@ jobs:
     # macOS dependencies
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install wabt llvm wasm-tools
-
-    - name: Add LLVM to PATH (macOS)
-      if: runner.os == 'macOS'
-      run: echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+      run: brew install wabt emscripten
 
     # Windows dependencies
     - name: Install LLVM (Windows)
@@ -97,7 +93,8 @@ jobs:
       if: runner.os == 'macOS'
       working-directory: TestCCode
       run: |
-        clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -fuse-ld=lld -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
+        EMSDK_CLANG=$(dirname $(which emcc))/../libexec/llvm/bin/clang
+        $EMSDK_CLANG --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
 
     - name: Build callback_test.wasm (Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       if: runner.os == 'macOS'
       working-directory: TestCCode
       run: |
-        $(brew --prefix llvm)/bin/clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
+        $(brew --prefix llvm)/bin/clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -fuse-ld=$(brew --prefix llvm)/bin/wasm-ld -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
 
     - name: Build callback_test.wasm (Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     # macOS dependencies
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install wabt llvm
+      run: brew install wabt llvm wasm-tools
 
     - name: Add LLVM to PATH (macOS)
       if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       if: runner.os == 'macOS'
       working-directory: TestCCode
       run: |
-        $(brew --prefix llvm)/bin/clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -fuse-ld=$(brew --prefix llvm)/bin/wasm-ld -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
+        clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -fuse-ld=lld -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
 
     - name: Build callback_test.wasm (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
The clang driver was failing to find wasm-ld with "posix_spawn failed: No such file or directory" error. Adding -fuse-ld flag with the explicit path to Homebrew's wasm-ld fixes the linker discovery issue.