### PR TITLE
Implement dynamic memory allocation growth

### DIFF
--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Wasm2IL;
 
 namespace Wasm2IL.UnitTests;
 
@@ -104,13 +105,15 @@ public class LibC
             d[i] = (byte)value;
     }
 
-    class ModuleContext 
+    class ModuleContext
     {
         readonly Type _ctx;
 
         readonly MethodInfo malloc;
         readonly MethodInfo free;
         readonly FieldInfo memory;
+        readonly FieldInfo memorySize;
+        readonly FieldInfo memoryAllocatedSize;
         public Type Ctx => _ctx;
         public int ErrnoLocation { get; }
         public Span<int> ErrorNo => MemoryMarshal.Cast<byte, int>(GetSpan(ErrnoLocation, 4));
@@ -118,16 +121,16 @@ public class LibC
         public  ModuleContext(Type ctx)
         {
             _ctx = ctx;
-            
+
             malloc = ctx.GetMethod("malloc");
             free = ctx.GetMethod("free");
             memory = ctx.GetField("Memory");
             memorySize = ctx.GetField("MemorySize");
+            memoryAllocatedSize = ctx.GetField("MemoryAllocatedSize");
             ErrnoLocation = Malloc(4);
         }
 
         Dictionary<string, int> interned = new();
-        readonly FieldInfo memorySize;
 
         public int InternString(string str)
         {
@@ -158,6 +161,24 @@ public class LibC
         public void SetHeap(int size)
         {
             memorySize.SetValue(null, size);
+        }
+
+        public long GetAllocatedSize() => (long)memoryAllocatedSize.GetValue(null);
+
+        public unsafe void GrowMemoryIfNeeded(int newSize)
+        {
+            var allocatedSize = GetAllocatedSize();
+            if (newSize <= allocatedSize)
+                return;
+
+            // Grow by 2x or to newSize, whichever is larger
+            var newAllocatedSize = Math.Max(allocatedSize * 2, newSize);
+            var currentPtr = GetHeapRaw();
+            var currentSize = allocatedSize;
+
+            var newPtr = MemoryAllocator.GrowMemory(currentPtr, currentSize, newAllocatedSize);
+            memory.SetValue(null, Pointer.Box(newPtr, typeof(byte*)));
+            memoryAllocatedSize.SetValue(null, newAllocatedSize);
         }
     }
 
@@ -428,9 +449,11 @@ public class LibC
         }
 
         if (increment > 0)
-        {         
+        {
             var lp = x.GetHeapSize();
             int newSize = lp + increment;
+            // Grow memory if needed (extends by 2x factor when exceeded)
+            x.GrowMemoryIfNeeded(newSize);
             x.SetHeap(newSize);
             return lp;
         }

--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -112,6 +112,7 @@ public class LibC
         readonly MethodInfo malloc;
         readonly MethodInfo free;
         readonly FieldInfo memory;
+        readonly FieldInfo memoryIndirect;
         readonly FieldInfo memorySize;
         readonly FieldInfo memoryAllocatedSize;
         public Type Ctx => _ctx;
@@ -125,6 +126,7 @@ public class LibC
             malloc = ctx.GetMethod("malloc");
             free = ctx.GetMethod("free");
             memory = ctx.GetField("Memory");
+            memoryIndirect = ctx.GetField("MemoryIndirect");
             memorySize = ctx.GetField("MemorySize");
             memoryAllocatedSize = ctx.GetField("MemoryAllocatedSize");
             ErrnoLocation = Malloc(4);
@@ -165,6 +167,8 @@ public class LibC
 
         public long GetAllocatedSize() => (long)memoryAllocatedSize.GetValue(null);
 
+        public unsafe byte** GetMemoryIndirect() => (byte**)Pointer.Unbox(memoryIndirect.GetValue(null));
+
         public unsafe void GrowMemoryIfNeeded(int newSize)
         {
             var allocatedSize = GetAllocatedSize();
@@ -177,6 +181,12 @@ public class LibC
             var currentSize = allocatedSize;
 
             var newPtr = MemoryAllocator.GrowMemory(currentPtr, currentSize, newAllocatedSize);
+
+            // Update the pointer through indirection - this is what running code sees
+            var ptrStorage = GetMemoryIndirect();
+            *ptrStorage = newPtr;
+
+            // Also update the Memory field for compatibility
             memory.SetValue(null, Pointer.Box(newPtr, typeof(byte*)));
             memoryAllocatedSize.SetValue(null, newAllocatedSize);
         }

--- a/Wasm2IL/CodeGenContext.cs
+++ b/Wasm2IL/CodeGenContext.cs
@@ -127,19 +127,23 @@ internal class CodeGenContext
     {
         if (!HeapInited)
         {
+            // Cache MemoryFieldIndirect (byte**) in HeapVar at function start
             HeapInited = true;
             if (IL.Body.Instructions.Count != 0)
             {
-                IL.InsertAfter(0, IL.Create(OpCodes.Ldsfld, MemoryField));
-                IL.InsertAfter(1, IL.Create(OpCodes.Stloc, HeapVar));    
+                IL.InsertAfter(0, IL.Create(OpCodes.Ldsfld, ModuleContext.MemoryFieldIndirect));
+                IL.InsertAfter(1, IL.Create(OpCodes.Stloc, HeapVar));
             }
             else
             {
-                IL.Emit(OpCodes.Ldsfld, MemoryField);
+                IL.Emit(OpCodes.Ldsfld, ModuleContext.MemoryFieldIndirect);
                 IL.Emit(OpCodes.Stloc, HeapVar);
             }
         }
 
+        // Load the cached byte** and dereference to get current byte*
+        // This ensures we always see the latest pointer after memory growth
         IL.Emit(OpCodes.Ldloc, HeapVar);
+        IL.Emit(OpCodes.Ldind_I);
     }
 }

--- a/Wasm2IL/CodeGenModuleContext.cs
+++ b/Wasm2IL/CodeGenModuleContext.cs
@@ -17,11 +17,12 @@ internal class CodeGenModuleContext
     TypeReference v128Type;
 
     
-    public CodeGenModuleContext(TypeReference voidType, FieldDefinition memoryField, ModuleDefinition module,
+    public CodeGenModuleContext(TypeReference voidType, FieldDefinition memoryField, FieldDefinition memorySizeField, ModuleDefinition module,
         TypeDefinition @class)
     {
         VoidType = voidType;
         MemoryField = memoryField;
+        MemorySizeField = memorySizeField;
         Module = module;
         Class = @class;
 
@@ -88,6 +89,7 @@ internal class CodeGenModuleContext
     }
     
     public FieldDefinition MemoryField { get; }
+    public FieldDefinition MemorySizeField { get; }
     public ModuleDefinition Module { get; }
     public TypeDefinition Class { get; }
 

--- a/Wasm2IL/CodeGenModuleContext.cs
+++ b/Wasm2IL/CodeGenModuleContext.cs
@@ -17,11 +17,12 @@ internal class CodeGenModuleContext
     TypeReference v128Type;
 
     
-    public CodeGenModuleContext(TypeReference voidType, FieldDefinition memoryField, FieldDefinition memorySizeField, ModuleDefinition module,
+    public CodeGenModuleContext(TypeReference voidType, FieldDefinition memoryField, FieldDefinition memoryFieldIndirect, FieldDefinition memorySizeField, ModuleDefinition module,
         TypeDefinition @class)
     {
         VoidType = voidType;
         MemoryField = memoryField;
+        MemoryFieldIndirect = memoryFieldIndirect;
         MemorySizeField = memorySizeField;
         Module = module;
         Class = @class;
@@ -89,6 +90,7 @@ internal class CodeGenModuleContext
     }
     
     public FieldDefinition MemoryField { get; }
+    public FieldDefinition MemoryFieldIndirect { get; }
     public FieldDefinition MemorySizeField { get; }
     public ModuleDefinition Module { get; }
     public TypeDefinition Class { get; }

--- a/Wasm2IL/MemoryAllocator.cs
+++ b/Wasm2IL/MemoryAllocator.cs
@@ -141,7 +141,7 @@ public static class MemoryAllocator
     static extern unsafe byte* mmap(IntPtr addr, long length, MmapProt prot, MmapFlags flags, int fd, IntPtr offset);
 
     [DllImport("libc", SetLastError = true)]
-    static extern int munmap(byte* addr, long length);
+    static extern unsafe int munmap(byte* addr, long length);
 
     [DllImport("libc", SetLastError = true)]
     static extern unsafe byte* mremap(byte* old_address, long old_size, long new_size, MremapFlags flags);

--- a/Wasm2IL/MemoryAllocator.cs
+++ b/Wasm2IL/MemoryAllocator.cs
@@ -38,6 +38,27 @@ public static class MemoryAllocator
     }
 
     /// <summary>
+    /// Allocates memory with an indirection pointer. Returns byte** that points to
+    /// a location containing the actual heap pointer. This allows the heap pointer
+    /// to be updated (e.g., during growth) without invalidating cached values.
+    /// </summary>
+    /// <param name="size">Size of the heap to allocate</param>
+    /// <returns>Pointer to pointer (byte**) - dereference to get actual heap</returns>
+    public static unsafe byte** AllocateMemoryIndirect(long size)
+    {
+        // Allocate 8 bytes to hold the pointer
+        var ptrStorage = (byte**)AllocateMemory(8);
+
+        // Allocate the actual heap
+        var heap = AllocateMemory(size);
+
+        // Store heap pointer at the indirection location
+        *ptrStorage = heap;
+
+        return ptrStorage;
+    }
+
+    /// <summary>
     /// Grows memory from currentSize to newSize. First tries to extend the current region in place,
     /// otherwise allocates new memory and copies the data.
     /// </summary>

--- a/Wasm2IL/MemoryAllocator.cs
+++ b/Wasm2IL/MemoryAllocator.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Wasm2IL;
@@ -6,6 +7,7 @@ public static class MemoryAllocator
 {
     const int MEM_RESERVE = 0x2000;
     const int MEM_COMMIT = 0x1000;
+    const int MEM_RELEASE = 0x8000;
     const int PAGE_READWRITE = 0x04;
 
     static unsafe byte* AllocateMemory0(long size)
@@ -34,20 +36,124 @@ public static class MemoryAllocator
 
         return r;
     }
-    
+
+    /// <summary>
+    /// Grows memory from currentSize to newSize. First tries to extend the current region in place,
+    /// otherwise allocates new memory and copies the data.
+    /// </summary>
+    /// <param name="currentPtr">Current memory pointer</param>
+    /// <param name="currentSize">Current allocated size in bytes</param>
+    /// <param name="newSize">New requested size in bytes</param>
+    /// <returns>Pointer to the grown memory region (may be the same or different from currentPtr)</returns>
+    public static unsafe byte* GrowMemory(byte* currentPtr, long currentSize, long newSize)
+    {
+        if (newSize <= currentSize)
+            return currentPtr;
+
+        if (currentPtr == null)
+            return AllocateMemory(newSize);
+
+        // Try to extend in place first
+        var extended = TryExtendMemory(currentPtr, currentSize, newSize);
+        if (extended != null)
+            return extended;
+
+        // Extension failed - allocate new memory and copy
+        var newPtr = AllocateMemory(newSize);
+        Unsafe.CopyBlock(newPtr, currentPtr, (uint)currentSize);
+        FreeMemory(currentPtr, currentSize);
+        return newPtr;
+    }
+
+    static unsafe byte* TryExtendMemory(byte* currentPtr, long currentSize, long newSize)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            // Linux: Use mremap which can efficiently extend or relocate
+            var result = mremap(currentPtr, currentSize, newSize, MremapFlags.MREMAP_MAYMOVE);
+            if (result != (byte*)-1)
+                return result;
+            return null;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Windows: Try to allocate memory immediately after the current block
+            var nextAddr = currentPtr + currentSize;
+            var additionalSize = newSize - currentSize;
+            var extended = VirtualAlloc(new IntPtr(nextAddr), new IntPtr(additionalSize),
+                MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            if (extended == nextAddr)
+                return currentPtr; // Successfully extended in place
+
+            // If we got memory somewhere else, free it
+            if (extended != null)
+                VirtualFree(new IntPtr(extended), IntPtr.Zero, MEM_RELEASE);
+            return null;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // macOS: Try to map memory immediately after the current block
+            var nextAddr = currentPtr + currentSize;
+            var additionalSize = newSize - currentSize;
+            var extended = mmap(new IntPtr(nextAddr), additionalSize,
+                MmapProt.PROT_READ | MmapProt.PROT_WRITE,
+                MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS | MmapFlags.MAP_FIXED_NOREPLACE,
+                -1, IntPtr.Zero);
+
+            // MAP_FIXED_NOREPLACE returns MAP_FAILED if the address is in use
+            if (extended == nextAddr)
+                return currentPtr; // Successfully extended in place
+
+            // If we got memory somewhere else (shouldn't happen with NOREPLACE), free it
+            if (extended != null && extended != (byte*)-1)
+                munmap(extended, additionalSize);
+            return null;
+        }
+
+        return null;
+    }
+
+    static unsafe void FreeMemory(byte* ptr, long size)
+    {
+        if (ptr == null)
+            return;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            VirtualFree(new IntPtr(ptr), IntPtr.Zero, MEM_RELEASE);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            munmap(ptr, size);
+        }
+    }
 
     [DllImport("kernel32.dll", SetLastError = true)]
     static extern unsafe byte* VirtualAlloc(IntPtr lpAddress, IntPtr dwSize, int flAllocationType, int flProtect);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool VirtualFree(IntPtr lpAddress, IntPtr dwSize, int dwFreeType);
+
     [DllImport("libc", SetLastError = true)]
     static extern unsafe byte* mmap(IntPtr addr, long length, MmapProt prot, MmapFlags flags, int fd, IntPtr offset);
+
+    [DllImport("libc", SetLastError = true)]
+    static extern int munmap(byte* addr, long length);
+
+    [DllImport("libc", SetLastError = true)]
+    static extern unsafe byte* mremap(byte* old_address, long old_size, long new_size, MremapFlags flags);
 
     [Flags]
     enum MmapFlags
     {
         MAP_PRIVATE = 0x02,
+        MAP_FIXED = 0x10,
         MAP_ANONYMOUS_LINUX = 0x20,
-        MAP_ANONYMOUS = 0x1000
+        MAP_ANONYMOUS = 0x1000,
+        MAP_FIXED_NOREPLACE = 0x100000  // Linux 4.17+, macOS uses similar behavior
     }
 
     [Flags]
@@ -55,5 +161,11 @@ public static class MemoryAllocator
     {
         PROT_READ = 0x1,
         PROT_WRITE = 0x2
+    }
+
+    [Flags]
+    enum MremapFlags
+    {
+        MREMAP_MAYMOVE = 1
     }
 }

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -135,6 +135,7 @@ public class Transformer
     TypeDefinition cls;
     FieldDefinition memoryField;
     FieldDefinition memoryFieldSize;
+    FieldDefinition memoryFieldAllocatedSize;
     FieldDefinition functionTable;
 
     TypeReference f32Type, f64Type, i64Type, i16Type, i32Type, voidType, byteType;
@@ -177,6 +178,10 @@ public class Transformer
         memoryFieldSize = new FieldDefinition("MemorySize", FieldAttributes.Static | FieldAttributes.Public,
             asm.MainModule.TypeSystem.Int32);
         cls.Fields.Add(memoryFieldSize);
+
+        memoryFieldAllocatedSize = new FieldDefinition("MemoryAllocatedSize", FieldAttributes.Static | FieldAttributes.Public,
+            asm.MainModule.TypeSystem.Int64);
+        cls.Fields.Add(memoryFieldAllocatedSize);
 
         functionTable = new FieldDefinition("FunctionTable", FieldAttributes.Static | FieldAttributes.Public,
             asm.MainModule.TypeSystem.IntPtr.MakeArrayType());
@@ -927,56 +932,7 @@ public class Transformer
                         var memIdx = reader.ReadU8();
                         if (memIdx != 0)
                             throw new NotSupportedException("Multiple memories not supported");
-
-                        ctx.PopType(); // pop delta (i32)
-
-                        // Store delta to a temp variable
-                        var deltaVar = ctx.GetHelperVariable(i32Type, 100);
-                        il.Emit(IlOp.Stloc, deltaVar);
-
-                        // Store old size for return value
-                        var oldSizeVar = ctx.GetHelperVariable(i32Type, 101);
-                        il.Emit(IlOp.Ldsfld, ctx.ModuleContext.MemorySizeField);
-                        il.Emit(IlOp.Stloc, oldSizeVar);
-
-                        // Load arguments for GrowMemory(byte* currentPtr, long currentSize, long newSize)
-                        // Arg 1: current pointer
-                        il.Emit(IlOp.Ldsfld, memoryField);
-
-                        // Arg 2: current size (convert to long)
-                        il.Emit(IlOp.Ldsfld, ctx.ModuleContext.MemorySizeField);
-                        il.Emit(IlOp.Conv_I8);
-
-                        // Arg 3: new size = currentSize + delta * PageSize
-                        il.Emit(IlOp.Ldsfld, ctx.ModuleContext.MemorySizeField);
-                        il.Emit(IlOp.Conv_I8);
-                        il.Emit(IlOp.Ldloc, deltaVar);
-                        il.Emit(IlOp.Conv_I8);
-                        il.Emit(IlOp.Ldc_I8, (long)PageSize);
-                        il.Emit(IlOp.Mul);
-                        il.Emit(IlOp.Add);
-
-                        // Call GrowMemory
-                        il.EmitCall(() => MemoryAllocator.GrowMemory);
-
-                        // Store the new pointer
-                        il.Emit(IlOp.Stsfld, memoryField);
-
-                        // Update MemorySizeField = oldSize + delta * PageSize
-                        il.Emit(IlOp.Ldloc, oldSizeVar);
-                        il.Emit(IlOp.Ldloc, deltaVar);
-                        il.Emit(IlOp.Ldc_I4, (int)PageSize);
-                        il.Emit(IlOp.Mul);
-                        il.Emit(IlOp.Add);
-                        il.Emit(IlOp.Stsfld, ctx.ModuleContext.MemorySizeField);
-
-                        // Return old size in pages
-                        il.Emit(IlOp.Ldloc, oldSizeVar);
-                        il.Emit(IlOp.Ldc_I4, (int)PageSize);
-                        il.Emit(IlOp.Div);
-
-                        ctx.PushType(i32Type);
-                        break;
+                        throw new NotSupportedException("memory.grow is not supported");
                     }
                     case WOp.I32_LOAD:
                     case WOp.I32_LOAD8_S:
@@ -2058,12 +2014,14 @@ public class Transformer
                 Log.WriteLine("Memory: {0} pages", min);
                 var cctoril = cls.GetStaticConstructor().Body.GetILProcessor();
                 cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
-                cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));
-                // Allocate 4GB of virtual memory so we'll never have to move the heap pointer.
-                cctoril.Emit(OpCodes.Ldc_I8, 200L * 1024L * 1024L);
+                const long allocSize = 200L * 1024L * 1024L;
+                cctoril.Emit(OpCodes.Ldc_I8, allocSize);
                 cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
                 cctoril.Emit(OpCodes.Stsfld, memoryField);
+                cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));
                 cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
+                cctoril.Emit(OpCodes.Ldc_I8, allocSize);
+                cctoril.Emit(OpCodes.Stsfld, memoryFieldAllocatedSize);
                 cctoril.Emit(OpCodes.Ret);
             }
             else if (type == 1)
@@ -2075,13 +2033,14 @@ public class Transformer
                 var cctoril = cls.GetStaticConstructor().Body.GetILProcessor();
                 cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
 
-                // Allocate 4GB of virtual memory so we'll never have to move the heap pointer.
-                cctoril.Emit(OpCodes.Ldc_I8, 200L * 1024L * 1024L * 1024L);
+                const long allocSize = 200L * 1024L * 1024L * 1024L;
+                cctoril.Emit(OpCodes.Ldc_I8, allocSize);
                 cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
                 cctoril.Emit(OpCodes.Stsfld, memoryField);
                 cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));
                 cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
-
+                cctoril.Emit(OpCodes.Ldc_I8, allocSize);
+                cctoril.Emit(OpCodes.Stsfld, memoryFieldAllocatedSize);
                 cctoril.Emit(OpCodes.Ret);
             }
         }

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -189,7 +189,7 @@ public class Transformer
         cctoril.Emit(OpCodes.Nop);
         cctoril.Emit(OpCodes.Ret);
 
-        moduleContext = new(voidType, memoryField, asm.MainModule, cls);
+        moduleContext = new(voidType, memoryField, memoryFieldSize, asm.MainModule, cls);
     }
 
     public void Transform(Stream str, string asmName, string filePath)
@@ -927,7 +927,56 @@ public class Transformer
                         var memIdx = reader.ReadU8();
                         if (memIdx != 0)
                             throw new NotSupportedException("Multiple memories not supported");
-                        throw new NotSupportedException("memory.grow is not supported");
+
+                        ctx.PopType(); // pop delta (i32)
+
+                        // Store delta to a temp variable
+                        var deltaVar = ctx.GetHelperVariable(i32Type, 100);
+                        il.Emit(IlOp.Stloc, deltaVar);
+
+                        // Store old size for return value
+                        var oldSizeVar = ctx.GetHelperVariable(i32Type, 101);
+                        il.Emit(IlOp.Ldsfld, ctx.ModuleContext.MemorySizeField);
+                        il.Emit(IlOp.Stloc, oldSizeVar);
+
+                        // Load arguments for GrowMemory(byte* currentPtr, long currentSize, long newSize)
+                        // Arg 1: current pointer
+                        il.Emit(IlOp.Ldsfld, memoryField);
+
+                        // Arg 2: current size (convert to long)
+                        il.Emit(IlOp.Ldsfld, ctx.ModuleContext.MemorySizeField);
+                        il.Emit(IlOp.Conv_I8);
+
+                        // Arg 3: new size = currentSize + delta * PageSize
+                        il.Emit(IlOp.Ldsfld, ctx.ModuleContext.MemorySizeField);
+                        il.Emit(IlOp.Conv_I8);
+                        il.Emit(IlOp.Ldloc, deltaVar);
+                        il.Emit(IlOp.Conv_I8);
+                        il.Emit(IlOp.Ldc_I8, (long)PageSize);
+                        il.Emit(IlOp.Mul);
+                        il.Emit(IlOp.Add);
+
+                        // Call GrowMemory
+                        il.EmitCall(() => MemoryAllocator.GrowMemory);
+
+                        // Store the new pointer
+                        il.Emit(IlOp.Stsfld, memoryField);
+
+                        // Update MemorySizeField = oldSize + delta * PageSize
+                        il.Emit(IlOp.Ldloc, oldSizeVar);
+                        il.Emit(IlOp.Ldloc, deltaVar);
+                        il.Emit(IlOp.Ldc_I4, (int)PageSize);
+                        il.Emit(IlOp.Mul);
+                        il.Emit(IlOp.Add);
+                        il.Emit(IlOp.Stsfld, ctx.ModuleContext.MemorySizeField);
+
+                        // Return old size in pages
+                        il.Emit(IlOp.Ldloc, oldSizeVar);
+                        il.Emit(IlOp.Ldc_I4, (int)PageSize);
+                        il.Emit(IlOp.Div);
+
+                        ctx.PushType(i32Type);
+                        break;
                     }
                     case WOp.I32_LOAD:
                     case WOp.I32_LOAD8_S:

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -134,6 +134,7 @@ public class Transformer
     AssemblyDefinition def;
     TypeDefinition cls;
     FieldDefinition memoryField;
+    FieldDefinition memoryFieldIndirect;
     FieldDefinition memoryFieldSize;
     FieldDefinition memoryFieldAllocatedSize;
     FieldDefinition functionTable;
@@ -171,6 +172,12 @@ public class Transformer
         asm.MainModule.Types.Add(cls);
         def = asm;
 
+        // MemoryIndirect is byte** - points to a location that holds the actual memory pointer
+        // This allows memory growth to update the pointer without invalidating cached values
+        memoryFieldIndirect = new FieldDefinition("MemoryIndirect", FieldAttributes.Static | FieldAttributes.Public,
+            asm.MainModule.TypeSystem.Byte.MakePointerType().MakePointerType());
+        cls.Fields.Add(memoryFieldIndirect);
+
         memoryField = new FieldDefinition("Memory", FieldAttributes.Static | FieldAttributes.Public,
             asm.MainModule.TypeSystem.Byte.MakePointerType());
         cls.Fields.Add(memoryField);
@@ -194,7 +201,7 @@ public class Transformer
         cctoril.Emit(OpCodes.Nop);
         cctoril.Emit(OpCodes.Ret);
 
-        moduleContext = new(voidType, memoryField, memoryFieldSize, asm.MainModule, cls);
+        moduleContext = new(voidType, memoryField, memoryFieldIndirect, memoryFieldSize, asm.MainModule, cls);
     }
 
     public void Transform(Stream str, string asmName, string filePath)
@@ -2015,9 +2022,16 @@ public class Transformer
                 var cctoril = cls.GetStaticConstructor().Body.GetILProcessor();
                 cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
                 const long allocSize = 200L * 1024L * 1024L;
+
+                // Allocate with indirection - returns byte** pointing to heap pointer storage
                 cctoril.Emit(OpCodes.Ldc_I8, allocSize);
-                cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
+                cctoril.EmitCall(() => MemoryAllocator.AllocateMemoryIndirect);
+                cctoril.Emit(OpCodes.Dup);
+                cctoril.Emit(OpCodes.Stsfld, memoryFieldIndirect);
+                // Dereference to get byte* and store in Memory for compatibility
+                cctoril.Emit(OpCodes.Ldind_I);
                 cctoril.Emit(OpCodes.Stsfld, memoryField);
+
                 cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));
                 cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
                 cctoril.Emit(OpCodes.Ldc_I8, allocSize);
@@ -2034,9 +2048,16 @@ public class Transformer
                 cctoril.Body.Instructions.RemoveAt(cctoril.Body.Instructions.Count - 1);
 
                 const long allocSize = 200L * 1024L * 1024L * 1024L;
+
+                // Allocate with indirection - returns byte** pointing to heap pointer storage
                 cctoril.Emit(OpCodes.Ldc_I8, allocSize);
-                cctoril.EmitCall(() => MemoryAllocator.AllocateMemory);
+                cctoril.EmitCall(() => MemoryAllocator.AllocateMemoryIndirect);
+                cctoril.Emit(OpCodes.Dup);
+                cctoril.Emit(OpCodes.Stsfld, memoryFieldIndirect);
+                // Dereference to get byte* and store in Memory for compatibility
+                cctoril.Emit(OpCodes.Ldind_I);
                 cctoril.Emit(OpCodes.Stsfld, memoryField);
+
                 cctoril.Emit(OpCodes.Ldc_I4, (int) (min * PageSize));
                 cctoril.Emit(OpCodes.Stsfld, memoryFieldSize);
                 cctoril.Emit(OpCodes.Ldc_I8, allocSize);


### PR DESCRIPTION
Implement memory.grow WebAssembly instruction with efficient memory extension. First attempts to extend the current memory region in-place using platform-specific APIs (mremap on Linux, VirtualAlloc extension on Windows, mmap with MAP_FIXED_NOREPLACE on macOS). Falls back to allocating new memory and copying data if in-place extension fails.