### PR TITLE
Add support for threading opcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     # Linux dependencies
     - name: Install APT packages (Linux)
       if: runner.os == 'Linux'
-      run: apt install wabt clang lld lld-21
+      run: sudo apt install wabt clang lld lld-21
 
     # macOS dependencies
     - name: Install dependencies (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,14 @@ jobs:
           ${{ runner.os }}-nuget-
 
     # Linux dependencies
-    - name: Cache APT packages (Linux)
+    - name: Install APT packages (Linux)
       if: runner.os == 'Linux'
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: wabt clang lld
-        version: 1.0
+      run: apt install wabt clang lld lld-21
 
     # macOS dependencies
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: | 
-        brew install wabt llvm lld      
+      run: brew install wabt llvm lld      
 
     - name: Add LLVM to PATH (macOS)
       if: runner.os == 'macOS'
@@ -89,7 +85,7 @@ jobs:
       run: |
         Invoke-WebRequest -Uri "https://github.com/rolfrm/minlibc/releases/download/prototype1/libc.wasm" -OutFile "TestCCode/libc.wasm"
 
-    - name: Build callback_test.wasm (Linux)
+    - name: Make
       run: make
       working-directory: TestCCode
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,22 +90,8 @@ jobs:
         Invoke-WebRequest -Uri "https://github.com/rolfrm/minlibc/releases/download/prototype1/libc.wasm" -OutFile "TestCCode/libc.wasm"
 
     - name: Build callback_test.wasm (Linux)
-      if: runner.os == 'Linux'
-      run: make callback_test.wasm
+      run: make
       working-directory: TestCCode
-
-    - name: Build callback_test.wasm (macOS)
-      if: runner.os == 'macOS'
-      working-directory: TestCCode
-      run: |
-        $(brew --prefix llvm)/bin/clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
-
-    - name: Build callback_test.wasm (Windows)
-      if: runner.os == 'Windows'
-      shell: cmd
-      working-directory: TestCCode
-      run: |
-        clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory -Wl,--export=main -Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            name: Linux
+          #- os: ubuntu-latest
+          #  name: Linux
           - os: macos-26
             name: macOS (M1)
           - os: windows-latest

--- a/README.md
+++ b/README.md
@@ -49,16 +49,17 @@ WASM linear memory is represented as a native `byte*` pointer, and function tabl
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Direct IL Generation** | Compiles WASM directly to .NET IL using Mono.Cecil, producing standard .NET assemblies |
-| **WASM 1.0 Support** | Handles most WASM32 1.0 instructions including arithmetic, memory, control flow, and type conversions |
-| **SIMD Operations** | Vector128 support for WASM SIMD instructions |
-| **C# Interop** | Import C# methods into WASM and export WASM functions for C# to call |
-| **Typed Wrappers** | Use `AsImplementation<T>` to create clean, strongly-typed C# interfaces over WASM exports |
-| **Automatic Marshaling** | Strings and `Span<byte>` are automatically copied to/from WASM heap memory |
-| **Memory Access** | Direct heap access via spans and pointers for advanced scenarios |
-| **Optimization** | Constant folding and peephole optimization for cleaner IL output |
+| Feature                  | Description                                                                                           |
+|--------------------------|-------------------------------------------------------------------------------------------------------|
+| **Direct IL Generation** | Compiles WASM directly to .NET IL using Mono.Cecil, producing standard .NET assemblies                |
+| **WASM 1.0 Support**     | Handles most WASM32 1.0 instructions including arithmetic, memory, control flow, and type conversions |
+| **SIMD Operations**      | Vector128 support for WASM SIMD instructions                                                          |
+| **C# Interop**           | Import C# methods into WASM and export WASM functions for C# to call                                  |
+| **Typed Wrappers**       | Use `AsImplementation<T>` to create clean, strongly-typed C# interfaces over WASM exports             |
+| **Automatic Marshaling** | Strings and `Span<byte>` are automatically copied to/from WASM heap memory                            |
+| **Memory Access**        | Direct heap access via spans and pointers for advanced scenarios                                      |
+| **Optimization**         | Constant folding and peephole optimization for cleaner IL output                                      |
+| **Threadng / Atomics**   | WASM modules compiled with -matomics can start threads and synchronize data.                          |
 
 ### Not supported Features
 

--- a/TestCCode/code1.c
+++ b/TestCCode/code1.c
@@ -14,6 +14,15 @@
 #define F_UNLCK 2
 #define F_GETLK  5
 #define F_SETLK 6
+unsigned char malloc_buffer[1024 * 16];
+size_t offset = 0;
+void * malloc(size_t size)
+{
+    void * p = malloc_buffer + offset;
+    offset += size;
+    return p;
+}
+
 int AddNumbers(int a, int b)
 {
     return a + b;
@@ -596,12 +605,37 @@ int GoTest()
     fflush(stdout);
     return result;
 }
+
 int main(){
     GoTest();
 }
+__attribute__((import_module("sys")))
+void * start_thread(void (* f) (void * userdata), void * userdata);
+__attribute__((import_module("sys")))
+void join_thread(void * thread_ptr);
 
-_Atomic int x;
-__attribute__((visibility("default")))
-void f(void) {
-    atomic_fetch_add(&x, 1);
+__attribute__((import_module("sys")))
+void stdout_string(char * str);
+
+_Atomic int atomx = 0;
+
+void test_thread(void * x)
+{
+    atomic_fetch_add(&atomx, 1);
 }
+__attribute__((visibility("default")))
+int testAtomics(void) {
+    void * t = start_thread(test_thread, NULL);
+    void * t2 = start_thread(test_thread, NULL);
+    void * t3 = start_thread(test_thread, NULL);
+    void * t4 = start_thread(test_thread, NULL);
+    
+    atomic_fetch_add(&atomx, 1);
+    join_thread(t);
+    join_thread(t2);
+    join_thread(t3);
+    join_thread(t4);
+    stdout_string("Thread completed\n");
+    return atomic_fetch_add(&atomx, 0);
+}
+

--- a/TestCCode/makefile
+++ b/TestCCode/makefile
@@ -7,7 +7,7 @@ minlibc:
 	mkdir minlibc
 	cd minlibc; unzip ../minlibc.zip
 
-sqlite3.wasm: sqlite3.c sqlite3.h
+sqlite3.wasm: sqlite3.c sqlite3.h minlibc
 	clang --target=wasm32-unknown-unknown -mrelaxed-simd -msimd128 -mtail-call -mbulk-memory -mbulk-memory-opt -flto=full -fbuiltin -nostdlib -Wl,--gc-sections -DSQLITE_OMIT_LOAD_EXTENSION -o sqlite3.wasm -O3 -g0\
 	         -ffast-math -fno-math-errno -funsafe-math-optimizations -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -fno-inline-functions \
              -I$(MUSL_INCLUDE) \
@@ -35,10 +35,10 @@ simple_call.wasm: simple_call.c
 simple_call2.wasm: simple_call2.c
 	clang --std=c23 --target=wasm32-unknown-unknown -nostdlib -O3 -mmultimemory  -Wl,--export=main -Wl,--export=__provide_overrides2__ -Wl,--export=__provide_overrides__ -Wl,--export=__caller_heap__ -Wl,--allow-undefined -Wl,--no-entry -ffreestanding simple_call2.c -o simple_call2.wasm
 	 
-callback_test.wasm: callback_test.c
+callback_test.wasm: callback_test.c minlibc
 	clang --std=c23 --target=wasm32-none -nostdlib -O3 -mmultimemory  -Wl,--export=main-Wl,--export=callback_test -Wl,--allow-undefined -Wl,--no-entry -ffreestanding callback_test.c -o callback_test.wasm 
   
-code1.bc: code1.c
+code1.bc: code1.c minlibc
 	clang --target=wasm32-none -I$(MUSL_INCLUDE) -matomics -v -c -o code1.bc code1.c 
 
 code.wasm: code1.bc

--- a/TestCCode/makefile
+++ b/TestCCode/makefile
@@ -8,7 +8,7 @@ minlibc:
 	cd minlibc; unzip ../minlibc.zip
 
 sqlite3.wasm: sqlite3.c sqlite3.h minlibc
-	clang --target=wasm32-unknown-unknown -mrelaxed-simd -msimd128 -mtail-call -mbulk-memory -mbulk-memory-opt -flto=full -fbuiltin -nostdlib -Wl,--gc-sections -DSQLITE_OMIT_LOAD_EXTENSION -o sqlite3.wasm -O3 -g0\
+	clang --target=wasm32-unknown-unknown -mrelaxed-simd -msimd128 -mtail-call -mbulk-memory -flto=full -fbuiltin -nostdlib -Wl,--gc-sections -DSQLITE_OMIT_LOAD_EXTENSION -o sqlite3.wasm -O3 -g0\
 	         -ffast-math -fno-math-errno -funsafe-math-optimizations -fstrict-aliasing -fomit-frame-pointer -fno-unroll-loops -fno-inline-functions \
              -I$(MUSL_INCLUDE) \
              -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_WAL -DHAVE_UTIME -DSQLITE_MAX_MMAP_SIZE=0 -DSQLITE_ENABLE_SETLK_TIMEOUT -DSQLITE_OMIT_UTF16 -DSQLITE_OMIT_JSON -DSQLITE_OMIT_RTREE -DSQLITE_OMIT_GEOPOLY -DSQLITE_OMIT_FTS5 -DSQLITE_OMIT_DEPRECATED   \
@@ -21,7 +21,7 @@ sqlite3.wasm: sqlite3.c sqlite3.h minlibc
               -Wl,--export=malloc -Wl,--export=free
               
 sqlite3.bc: sqlite3.c sqlite3.h
-	clang --target=wasm32-unknown-unknown -c -msimd128  -mbulk-memory -mbulk-memory-opt -flto -fbuiltin -mllvm -inline-threshold=1000 -nostdlib -Wl,--gc-sections -DSQLITE_OMIT_LOAD_EXTENSION -o sqlite3.bc -O3 -g0\
+	clang --target=wasm32-unknown-unknown -c -msimd128  -mbulk-memory -flto -fbuiltin -mllvm -inline-threshold=1000 -nostdlib -Wl,--gc-sections -DSQLITE_OMIT_LOAD_EXTENSION -o sqlite3.bc -O3 -g0\
              -I$(MUSL_INCLUDE)  \
              -DSQLITE_THREADSAFE=0 -DHAVE_UTIME -DSQLITE_MAX_MMAP_SIZE=0 -DSQLITE_ENABLE_SETLK_TIMEOUT -DSQLITE_OMIT_UTF16 -DSQLITE_OMIT_JSON -DSQLITE_OMIT_RTREE -DSQLITE_OMIT_GEOPOLY -DSQLITE_OMIT_FTS5 -DSQLITE_OMIT_DEPRECATED   \
               sqlite3.c -Wl,--allow-undefined 

--- a/TestCCode/makefile
+++ b/TestCCode/makefile
@@ -1,10 +1,11 @@
-SYSROOT=/Users/bruger/code/work/wasi-libc/sysroot
-SYSROOT_LIB=$(SYSROOT)/lib/wasm32-wasi
-#MUSL_INCLUDE=/Users/bruger/code/work/musl/include
-MUSL_INCLUDE=/Users/bruger/code/minlibc/include
-SSL_PATH=/Users/bruger/code/extern/openssl/include
+MUSL_INCLUDE=minlibc/include
 all: sqlite3.wasm callback_test.wasm code.wasm
 # -msimd128  -mtail-call ./libc.wasm-mtail-call  -msimd128 -mbulk-memory -msimd128 
+
+minlibc:
+	curl -L -o minlibc.zip https://github.com/rolfrm/minlibc/releases/download/prototype1/include.zip
+	mkdir minlibc
+	cd minlibc; unzip ../minlibc.zip
 
 sqlite3.wasm: sqlite3.c sqlite3.h
 	clang --target=wasm32-unknown-unknown -mrelaxed-simd -msimd128 -mtail-call -mbulk-memory -mbulk-memory-opt -flto=full -fbuiltin -nostdlib -Wl,--gc-sections -DSQLITE_OMIT_LOAD_EXTENSION -o sqlite3.wasm -O3 -g0\

--- a/Wasm2IL.UnitTests/LibC.cs
+++ b/Wasm2IL.UnitTests/LibC.cs
@@ -82,6 +82,30 @@ public class LibC
         }
         
     }
+
+    static Dictionary<int, Thread> threads = new();
+    static int threadid = 0;
+
+    public static int start_thread(HeapContext ctx, int function, int userdata)
+    {
+        var id = Interlocked.Increment(ref threadid);
+        var ctx2 = GetModuleContext(ctx.Module);
+        var m = ctx2.LookupFunction(function) as MethodInfo;
+        
+        var thread = new Thread(() => m.Invoke(null, [userdata]));
+        thread.Start();
+        threads[id] = thread;
+        return id;
+    }
+    public static void join_thread(int threadid)
+    {
+        threads[threadid].Join();
+    }
+
+    public static void stdout_string(CString msg)
+    {
+        Console.Write(msg.ToString());
+    }
     
     public static int strlen(CString p)
     {
@@ -158,6 +182,12 @@ public class LibC
         public void SetHeap(int size)
         {
             memorySize.SetValue(null, size);
+        }
+
+        public object LookupFunction(int i)
+        {
+            var m = Ctx.GetMethods().FirstOrDefault(m => m.GetCustomAttribute<FunctionExportAttribute>()?.Id == i);
+            return m;
         }
     }
 

--- a/Wasm2IL.UnitTests/TestBasicWasm.cs
+++ b/Wasm2IL.UnitTests/TestBasicWasm.cs
@@ -246,6 +246,8 @@ public class TestBasicWasm
     public void TestAtomics()
     {
         var wasmPath = Path.Combine(AppContext.BaseDirectory, "code.wasm");
-        var asm = Transformer.Transform(wasmPath, []);
+        var asm = Transformer.Transform(wasmPath, [("sys", typeof(LibC))]);
+        var atomx= (int)asm.Invoke("testAtomics", []);
+        Assert.AreEqual(atomx, 5);
     }
 }

--- a/Wasm2IL/CodeGenContext.cs
+++ b/Wasm2IL/CodeGenContext.cs
@@ -65,6 +65,11 @@ internal class CodeGenContext
                         var b = reader.ReadByte();
                         IL.Emit(OpCodes.Ldc_I4, (int)b);
                     }
+                    if (param.ParameterType == typeof(int))
+                    {
+                        var b = reader.ReadU32Leb();
+                        IL.Emit(OpCodes.Ldc_I4, (int)b);
+                    }
 
                 }
             }

--- a/Wasm2IL/CodeGenModuleContext.cs
+++ b/Wasm2IL/CodeGenModuleContext.cs
@@ -84,6 +84,7 @@ internal class CodeGenModuleContext
         if (r == typeof(Vector128<double>)) return v128Type;
         if (r == typeof(void)) return voidType;
         if (r.IsPointer) return i32Type;
+        if (r == typeof(HeapContext)) return Module.ImportReference(typeof(HeapContext));
         throw new Exception("unrecognized type");
     }
     

--- a/Wasm2IL/FunctionExportAttribute.cs
+++ b/Wasm2IL/FunctionExportAttribute.cs
@@ -1,0 +1,11 @@
+namespace Wasm2IL;
+
+public class FunctionExportAttribute : Attribute
+{
+    public FunctionExportAttribute(int id)
+    {
+        Id = id;
+    }
+
+    public int Id { get; }
+}

--- a/Wasm2IL/Lib.cs
+++ b/Wasm2IL/Lib.cs
@@ -224,6 +224,11 @@ public class WasmOpcodeAttribute : Attribute
     {
         Key = instruction;
     }
+
+    public WasmOpcodeAttribute(AtomicInstruction instruction)
+    {
+        Key = instruction;
+    }
 }
 
 public class WasmConstAttribute : Attribute

--- a/Wasm2IL/Lib_Atomic.cs
+++ b/Wasm2IL/Lib_Atomic.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Wasm;
 
 namespace Wasm2IL;
@@ -20,9 +19,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD)]
-    public static unsafe int I32AtomicLoad(int* addr)
+    public static unsafe int I32AtomicLoad(HeapContext ctx, int addr)
     {
-        return Volatile.Read(ref *addr);
+        var mem = (byte * ) (IntPtr)ctx.Module.GetField("Memory").GetValue(null);
+        
+        return Volatile.Read(ref *(mem + addr));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -122,9 +123,9 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_ADD)]
-    public static unsafe int I32AtomicRmwAdd(int* addr, int value)
+    public static unsafe int I32AtomicRmwAdd(int* addr, int value,[WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Add(ref *addr, value) - value;
+        return Interlocked.Add(ref *(addr + offset), value) - value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Wasm2IL/Lib_Atomic.cs
+++ b/Wasm2IL/Lib_Atomic.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Wasm;
 
 namespace Wasm2IL;
@@ -19,128 +20,127 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD)]
-    public static unsafe int I32AtomicLoad(HeapContext ctx, int addr)
+    public static unsafe int I32AtomicLoad(int* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        var mem = (byte * ) (IntPtr)ctx.Module.GetField("Memory").GetValue(null);
-        
-        return Volatile.Read(ref *(mem + addr));
+        return Volatile.Read(ref *(addr + offset));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD)]
-    public static unsafe long I64AtomicLoad(long* addr)
+    public static unsafe long I64AtomicLoad(long* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Read(ref *addr);
+        return Interlocked.Read(ref *(addr + offset));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD8_U)]
-    public static unsafe int I32AtomicLoad8U(byte* addr)
+    public static unsafe int I32AtomicLoad8U(byte* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Volatile.Read(ref *addr);
+        return Volatile.Read(ref *(addr + offset));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD16_U)]
-    public static unsafe int I32AtomicLoad16U(ushort* addr)
+    public static unsafe int I32AtomicLoad16U(ushort* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Volatile.Read(ref *addr);
+        return Volatile.Read(ref *(addr + offset));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD8_U)]
-    public static unsafe long I64AtomicLoad8U(byte* addr)
+    public static unsafe long I64AtomicLoad8U(byte* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Volatile.Read(ref *addr);
+        return Volatile.Read(ref *(addr + offset));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD16_U)]
-    public static unsafe long I64AtomicLoad16U(ushort* addr)
+    public static unsafe long I64AtomicLoad16U(ushort* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Volatile.Read(ref *addr);
+        return Volatile.Read(ref *(addr + offset));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD32_U)]
-    public static unsafe long I64AtomicLoad32U(uint* addr)
+    public static unsafe long I64AtomicLoad32U(uint* addr, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Volatile.Read(ref *addr);
+        return Volatile.Read(ref *(addr + offset));
     }
 
     // ==================== Atomic Store Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_STORE)]
-    public static unsafe void I32AtomicStore(int* addr, int value)
+    public static unsafe void I32AtomicStore(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Volatile.Write(ref *addr, value);
+        Volatile.Write(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE)]
-    public static unsafe void I64AtomicStore(long* addr, long value)
+    public static unsafe void I64AtomicStore(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Interlocked.Exchange(ref *addr, value);
+        Interlocked.Exchange(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_STORE8)]
-    public static unsafe void I32AtomicStore8(byte* addr, int value)
+    public static unsafe void I32AtomicStore8(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Volatile.Write(ref *addr, (byte)value);
+        Volatile.Write(ref *(addr + offset), (byte)value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_STORE16)]
-    public static unsafe void I32AtomicStore16(ushort* addr, int value)
+    public static unsafe void I32AtomicStore16(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Volatile.Write(ref *addr, (ushort)value);
+        Volatile.Write(ref *(addr + offset), (ushort)value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE8)]
-    public static unsafe void I64AtomicStore8(byte* addr, long value)
+    public static unsafe void I64AtomicStore8(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Volatile.Write(ref *addr, (byte)value);
+        Volatile.Write(ref *(addr + offset), (byte)value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE16)]
-    public static unsafe void I64AtomicStore16(ushort* addr, long value)
+    public static unsafe void I64AtomicStore16(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Volatile.Write(ref *addr, (ushort)value);
+        Volatile.Write(ref *(addr + offset), (ushort)value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE32)]
-    public static unsafe void I64AtomicStore32(uint* addr, long value)
+    public static unsafe void I64AtomicStore32(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        Volatile.Write(ref *addr, (uint)value);
+        Volatile.Write(ref *(addr + offset), (uint)value);
     }
 
     // ==================== Atomic RMW Add Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_ADD)]
-    public static unsafe int I32AtomicRmwAdd(int* addr, int value,[WasmConst] byte align, [WasmConst] int offset)
+    public static unsafe int I32AtomicRmwAdd(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
         return Interlocked.Add(ref *(addr + offset), value) - value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_ADD)]
-    public static unsafe long I64AtomicRmwAdd(long* addr, long value)
+    public static unsafe long I64AtomicRmwAdd(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Add(ref *addr, value) - value;
+        return Interlocked.Add(ref *(addr + offset), value) - value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_ADD_U)]
-    public static unsafe int I32AtomicRmw8AddU(byte* addr, int value)
+    public static unsafe int I32AtomicRmw8AddU(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int oldWord, newWord;
         do
@@ -155,10 +155,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_ADD_U)]
-    public static unsafe int I32AtomicRmw16AddU(ushort* addr, int value)
+    public static unsafe int I32AtomicRmw16AddU(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int oldWord, newWord;
         do
@@ -173,47 +174,48 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_ADD_U)]
-    public static unsafe long I64AtomicRmw8AddU(byte* addr, long value)
+    public static unsafe long I64AtomicRmw8AddU(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8AddU(addr, (int)value);
+        return I32AtomicRmw8AddU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_ADD_U)]
-    public static unsafe long I64AtomicRmw16AddU(ushort* addr, long value)
+    public static unsafe long I64AtomicRmw16AddU(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16AddU(addr, (int)value);
+        return I32AtomicRmw16AddU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_ADD_U)]
-    public static unsafe long I64AtomicRmw32AddU(uint* addr, long value)
+    public static unsafe long I64AtomicRmw32AddU(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return (uint)(Interlocked.Add(ref *(int*)addr, (int)value) - (int)value);
+        return (uint)(Interlocked.Add(ref *(int*)(addr + offset), (int)value) - (int)value);
     }
 
     // ==================== Atomic RMW Sub Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_SUB)]
-    public static unsafe int I32AtomicRmwSub(int* addr, int value)
+    public static unsafe int I32AtomicRmwSub(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Add(ref *addr, -value) + value;
+        return Interlocked.Add(ref *(addr + offset), -value) + value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_SUB)]
-    public static unsafe long I64AtomicRmwSub(long* addr, long value)
+    public static unsafe long I64AtomicRmwSub(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Add(ref *addr, -value) + value;
+        return Interlocked.Add(ref *(addr + offset), -value) + value;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_SUB_U)]
-    public static unsafe int I32AtomicRmw8SubU(byte* addr, int value)
+    public static unsafe int I32AtomicRmw8SubU(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int oldWord, newWord;
         do
@@ -228,10 +230,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_SUB_U)]
-    public static unsafe int I32AtomicRmw16SubU(ushort* addr, int value)
+    public static unsafe int I32AtomicRmw16SubU(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int oldWord, newWord;
         do
@@ -246,47 +249,48 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_SUB_U)]
-    public static unsafe long I64AtomicRmw8SubU(byte* addr, long value)
+    public static unsafe long I64AtomicRmw8SubU(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8SubU(addr, (int)value);
+        return I32AtomicRmw8SubU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_SUB_U)]
-    public static unsafe long I64AtomicRmw16SubU(ushort* addr, long value)
+    public static unsafe long I64AtomicRmw16SubU(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16SubU(addr, (int)value);
+        return I32AtomicRmw16SubU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_SUB_U)]
-    public static unsafe long I64AtomicRmw32SubU(uint* addr, long value)
+    public static unsafe long I64AtomicRmw32SubU(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return (uint)(Interlocked.Add(ref *(int*)addr, -(int)value) + (int)value);
+        return (uint)(Interlocked.Add(ref *(int*)(addr + offset), -(int)value) + (int)value);
     }
 
     // ==================== Atomic RMW And Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_AND)]
-    public static unsafe int I32AtomicRmwAnd(int* addr, int value)
+    public static unsafe int I32AtomicRmwAnd(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.And(ref *addr, value);
+        return Interlocked.And(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_AND)]
-    public static unsafe long I64AtomicRmwAnd(long* addr, long value)
+    public static unsafe long I64AtomicRmwAnd(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.And(ref *addr, value);
+        return Interlocked.And(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_AND_U)]
-    public static unsafe int I32AtomicRmw8AndU(byte* addr, int value)
+    public static unsafe int I32AtomicRmw8AndU(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int oldWord, newWord;
         do
@@ -301,10 +305,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_AND_U)]
-    public static unsafe int I32AtomicRmw16AndU(ushort* addr, int value)
+    public static unsafe int I32AtomicRmw16AndU(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int oldWord, newWord;
         do
@@ -319,47 +324,48 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_AND_U)]
-    public static unsafe long I64AtomicRmw8AndU(byte* addr, long value)
+    public static unsafe long I64AtomicRmw8AndU(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8AndU(addr, (int)value);
+        return I32AtomicRmw8AndU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_AND_U)]
-    public static unsafe long I64AtomicRmw16AndU(ushort* addr, long value)
+    public static unsafe long I64AtomicRmw16AndU(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16AndU(addr, (int)value);
+        return I32AtomicRmw16AndU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_AND_U)]
-    public static unsafe long I64AtomicRmw32AndU(uint* addr, long value)
+    public static unsafe long I64AtomicRmw32AndU(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return (uint)Interlocked.And(ref *(int*)addr, (int)value);
+        return (uint)Interlocked.And(ref *(int*)(addr + offset), (int)value);
     }
 
     // ==================== Atomic RMW Or Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_OR)]
-    public static unsafe int I32AtomicRmwOr(int* addr, int value)
+    public static unsafe int I32AtomicRmwOr(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Or(ref *addr, value);
+        return Interlocked.Or(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_OR)]
-    public static unsafe long I64AtomicRmwOr(long* addr, long value)
+    public static unsafe long I64AtomicRmwOr(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Or(ref *addr, value);
+        return Interlocked.Or(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_OR_U)]
-    public static unsafe int I32AtomicRmw8OrU(byte* addr, int value)
+    public static unsafe int I32AtomicRmw8OrU(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int oldWord, newWord;
         do
@@ -374,10 +380,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_OR_U)]
-    public static unsafe int I32AtomicRmw16OrU(ushort* addr, int value)
+    public static unsafe int I32AtomicRmw16OrU(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int oldWord, newWord;
         do
@@ -392,59 +399,62 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_OR_U)]
-    public static unsafe long I64AtomicRmw8OrU(byte* addr, long value)
+    public static unsafe long I64AtomicRmw8OrU(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8OrU(addr, (int)value);
+        return I32AtomicRmw8OrU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_OR_U)]
-    public static unsafe long I64AtomicRmw16OrU(ushort* addr, long value)
+    public static unsafe long I64AtomicRmw16OrU(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16OrU(addr, (int)value);
+        return I32AtomicRmw16OrU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_OR_U)]
-    public static unsafe long I64AtomicRmw32OrU(uint* addr, long value)
+    public static unsafe long I64AtomicRmw32OrU(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return (uint)Interlocked.Or(ref *(int*)addr, (int)value);
+        return (uint)Interlocked.Or(ref *(int*)(addr + offset), (int)value);
     }
 
     // ==================== Atomic RMW Xor Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_XOR)]
-    public static unsafe int I32AtomicRmwXor(int* addr, int value)
+    public static unsafe int I32AtomicRmwXor(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
+        var ptr = addr + offset;
         int oldVal, newVal;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
+            oldVal = Volatile.Read(ref *ptr);
             newVal = oldVal ^ value;
-        } while (Interlocked.CompareExchange(ref *addr, newVal, oldVal) != oldVal);
+        } while (Interlocked.CompareExchange(ref *ptr, newVal, oldVal) != oldVal);
         return oldVal;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_XOR)]
-    public static unsafe long I64AtomicRmwXor(long* addr, long value)
+    public static unsafe long I64AtomicRmwXor(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
+        var ptr = addr + offset;
         long oldVal, newVal;
         do
         {
-            oldVal = Interlocked.Read(ref *addr);
+            oldVal = Interlocked.Read(ref *ptr);
             newVal = oldVal ^ value;
-        } while (Interlocked.CompareExchange(ref *addr, newVal, oldVal) != oldVal);
+        } while (Interlocked.CompareExchange(ref *ptr, newVal, oldVal) != oldVal);
         return oldVal;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_XOR_U)]
-    public static unsafe int I32AtomicRmw8XorU(byte* addr, int value)
+    public static unsafe int I32AtomicRmw8XorU(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int oldWord, newWord;
         do
@@ -459,10 +469,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_XOR_U)]
-    public static unsafe int I32AtomicRmw16XorU(ushort* addr, int value)
+    public static unsafe int I32AtomicRmw16XorU(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int oldWord, newWord;
         do
@@ -477,28 +488,29 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_XOR_U)]
-    public static unsafe long I64AtomicRmw8XorU(byte* addr, long value)
+    public static unsafe long I64AtomicRmw8XorU(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8XorU(addr, (int)value);
+        return I32AtomicRmw8XorU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_XOR_U)]
-    public static unsafe long I64AtomicRmw16XorU(ushort* addr, long value)
+    public static unsafe long I64AtomicRmw16XorU(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16XorU(addr, (int)value);
+        return I32AtomicRmw16XorU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_XOR_U)]
-    public static unsafe long I64AtomicRmw32XorU(uint* addr, long value)
+    public static unsafe long I64AtomicRmw32XorU(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
+        var ptr = (int*)(addr + offset);
         int oldVal, newVal;
         do
         {
-            oldVal = Volatile.Read(ref *(int*)addr);
+            oldVal = Volatile.Read(ref *ptr);
             newVal = oldVal ^ (int)value;
-        } while (Interlocked.CompareExchange(ref *(int*)addr, newVal, oldVal) != oldVal);
+        } while (Interlocked.CompareExchange(ref *ptr, newVal, oldVal) != oldVal);
         return (uint)oldVal;
     }
 
@@ -506,24 +518,25 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_XCHG)]
-    public static unsafe int I32AtomicRmwXchg(int* addr, int value)
+    public static unsafe int I32AtomicRmwXchg(int* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Exchange(ref *addr, value);
+        return Interlocked.Exchange(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_XCHG)]
-    public static unsafe long I64AtomicRmwXchg(long* addr, long value)
+    public static unsafe long I64AtomicRmwXchg(long* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.Exchange(ref *addr, value);
+        return Interlocked.Exchange(ref *(addr + offset), value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_XCHG_U)]
-    public static unsafe int I32AtomicRmw8XchgU(byte* addr, int value)
+    public static unsafe int I32AtomicRmw8XchgU(byte* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int newByte = value & 0xFF;
         int oldWord, newWord;
@@ -537,10 +550,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_XCHG_U)]
-    public static unsafe int I32AtomicRmw16XchgU(ushort* addr, int value)
+    public static unsafe int I32AtomicRmw16XchgU(ushort* addr, int value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int newShort = value & 0xFFFF;
         int oldWord, newWord;
@@ -554,47 +568,48 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_XCHG_U)]
-    public static unsafe long I64AtomicRmw8XchgU(byte* addr, long value)
+    public static unsafe long I64AtomicRmw8XchgU(byte* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8XchgU(addr, (int)value);
+        return I32AtomicRmw8XchgU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_XCHG_U)]
-    public static unsafe long I64AtomicRmw16XchgU(ushort* addr, long value)
+    public static unsafe long I64AtomicRmw16XchgU(ushort* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16XchgU(addr, (int)value);
+        return I32AtomicRmw16XchgU(addr, (int)value, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_XCHG_U)]
-    public static unsafe long I64AtomicRmw32XchgU(uint* addr, long value)
+    public static unsafe long I64AtomicRmw32XchgU(uint* addr, long value, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return (uint)Interlocked.Exchange(ref *(int*)addr, (int)value);
+        return (uint)Interlocked.Exchange(ref *(int*)(addr + offset), (int)value);
     }
 
     // ==================== Atomic RMW Compare-Exchange Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_CMPXCHG)]
-    public static unsafe int I32AtomicRmwCmpxchg(int* addr, int expected, int replacement)
+    public static unsafe int I32AtomicRmwCmpxchg(int* addr, int expected, int replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.CompareExchange(ref *addr, replacement, expected);
+        return Interlocked.CompareExchange(ref *(addr + offset), replacement, expected);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_CMPXCHG)]
-    public static unsafe long I64AtomicRmwCmpxchg(long* addr, long expected, long replacement)
+    public static unsafe long I64AtomicRmwCmpxchg(long* addr, long expected, long replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return Interlocked.CompareExchange(ref *addr, replacement, expected);
+        return Interlocked.CompareExchange(ref *(addr + offset), replacement, expected);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_CMPXCHG_U)]
-    public static unsafe int I32AtomicRmw8CmpxchgU(byte* addr, int expected, int replacement)
+    public static unsafe int I32AtomicRmw8CmpxchgU(byte* addr, int expected, int replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 3) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 3) * 8);
         int mask = 0xFF << shift;
         int expectedByte = expected & 0xFF;
         int replacementByte = replacement & 0xFF;
@@ -612,10 +627,11 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_CMPXCHG_U)]
-    public static unsafe int I32AtomicRmw16CmpxchgU(ushort* addr, int expected, int replacement)
+    public static unsafe int I32AtomicRmw16CmpxchgU(ushort* addr, int expected, int replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        int* alignedAddr = (int*)((nint)addr & ~3);
-        int shift = (int)(((nint)addr & 2) * 8);
+        var ptr = addr + offset;
+        int* alignedAddr = (int*)((nint)ptr & ~3);
+        int shift = (int)(((nint)ptr & 2) * 8);
         int mask = 0xFFFF << shift;
         int expectedShort = expected & 0xFFFF;
         int replacementShort = replacement & 0xFFFF;
@@ -633,42 +649,43 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_CMPXCHG_U)]
-    public static unsafe long I64AtomicRmw8CmpxchgU(byte* addr, long expected, long replacement)
+    public static unsafe long I64AtomicRmw8CmpxchgU(byte* addr, long expected, long replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw8CmpxchgU(addr, (int)expected, (int)replacement);
+        return I32AtomicRmw8CmpxchgU(addr, (int)expected, (int)replacement, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_CMPXCHG_U)]
-    public static unsafe long I64AtomicRmw16CmpxchgU(ushort* addr, long expected, long replacement)
+    public static unsafe long I64AtomicRmw16CmpxchgU(ushort* addr, long expected, long replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return I32AtomicRmw16CmpxchgU(addr, (int)expected, (int)replacement);
+        return I32AtomicRmw16CmpxchgU(addr, (int)expected, (int)replacement, align, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_CMPXCHG_U)]
-    public static unsafe long I64AtomicRmw32CmpxchgU(uint* addr, long expected, long replacement)
+    public static unsafe long I64AtomicRmw32CmpxchgU(uint* addr, long expected, long replacement, [WasmConst] byte align, [WasmConst] int offset)
     {
-        return (uint)Interlocked.CompareExchange(ref *(int*)addr, (int)replacement, (int)expected);
+        return (uint)Interlocked.CompareExchange(ref *(int*)(addr + offset), (int)replacement, (int)expected);
     }
 
     // ==================== Memory Atomic Wait/Notify Operations ====================
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_NOTIFY)]
-    public static unsafe int MemoryAtomicNotify(int* addr, int count)
+    public static unsafe int MemoryAtomicNotify(int* addr, int count, [WasmConst] byte align, [WasmConst] int offset)
     {
-        lock (GetWaitLock(addr))
+        var ptr = addr + offset;
+        lock (GetWaitLock(ptr))
         {
             if (count == int.MaxValue)
             {
-                Monitor.PulseAll(GetWaitLock(addr));
+                Monitor.PulseAll(GetWaitLock(ptr));
             }
             else
             {
                 for (int i = 0; i < count; i++)
                 {
-                    Monitor.Pulse(GetWaitLock(addr));
+                    Monitor.Pulse(GetWaitLock(ptr));
                 }
             }
         }
@@ -677,27 +694,28 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_WAIT32)]
-    public static unsafe int MemoryAtomicWait32(int* addr, int expected, long timeout)
+    public static unsafe int MemoryAtomicWait32(int* addr, int expected, long timeout, [WasmConst] byte align, [WasmConst] int offset)
     {
-        if (Volatile.Read(ref *addr) != expected)
+        var ptr = addr + offset;
+        if (Volatile.Read(ref *ptr) != expected)
             return 1;
 
-        lock (GetWaitLock(addr))
+        lock (GetWaitLock(ptr))
         {
-            if (Volatile.Read(ref *addr) != expected)
+            if (Volatile.Read(ref *ptr) != expected)
                 return 1;
 
             bool signaled;
             if (timeout < 0)
             {
-                Monitor.Wait(GetWaitLock(addr));
+                Monitor.Wait(GetWaitLock(ptr));
                 signaled = true;
             }
             else
             {
                 int timeoutMs = (int)(timeout / 1_000_000);
                 if (timeoutMs == 0 && timeout > 0) timeoutMs = 1;
-                signaled = Monitor.Wait(GetWaitLock(addr), timeoutMs);
+                signaled = Monitor.Wait(GetWaitLock(ptr), timeoutMs);
             }
             return signaled ? 0 : 2;
         }
@@ -705,27 +723,28 @@ public partial class Lib
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_WAIT64)]
-    public static unsafe int MemoryAtomicWait64(long* addr, long expected, long timeout)
+    public static unsafe int MemoryAtomicWait64(long* addr, long expected, long timeout, [WasmConst] byte align, [WasmConst] int offset)
     {
-        if (Interlocked.Read(ref *addr) != expected)
+        var ptr = addr + offset;
+        if (Interlocked.Read(ref *ptr) != expected)
             return 1;
 
-        lock (GetWaitLock(addr))
+        lock (GetWaitLock(ptr))
         {
-            if (Interlocked.Read(ref *addr) != expected)
+            if (Interlocked.Read(ref *ptr) != expected)
                 return 1;
 
             bool signaled;
             if (timeout < 0)
             {
-                Monitor.Wait(GetWaitLock(addr));
+                Monitor.Wait(GetWaitLock(ptr));
                 signaled = true;
             }
             else
             {
                 int timeoutMs = (int)(timeout / 1_000_000);
                 if (timeoutMs == 0 && timeout > 0) timeoutMs = 1;
-                signaled = Monitor.Wait(GetWaitLock(addr), timeoutMs);
+                signaled = Monitor.Wait(GetWaitLock(ptr), timeoutMs);
             }
             return signaled ? 0 : 2;
         }

--- a/Wasm2IL/Lib_Atomic.cs
+++ b/Wasm2IL/Lib_Atomic.cs
@@ -139,46 +139,36 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_ADD_U)]
     public static unsafe int I32AtomicRmw8AddU(byte* addr, int value)
     {
-        byte oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (byte)(oldVal + value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
-            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
-        return oldVal;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ReplaceByteInInt(int value, int byteIndex, byte newByte)
-    {
-        int shift = byteIndex * 8;
-        return (value & ~(0xFF << shift)) | (newByte << shift);
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldByte = (oldWord >> shift) & 0xFF;
+            int newByte = (oldByte + value) & 0xFF;
+            newWord = (oldWord & ~mask) | (newByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_ADD_U)]
     public static unsafe int I32AtomicRmw16AddU(ushort* addr, int value)
     {
-        ushort oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (ushort)(oldVal + value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
-            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
-        return oldVal;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ReplaceShortInInt(int value, int shortIndex, ushort newShort)
-    {
-        int shift = shortIndex * 16;
-        return (value & ~(0xFFFF << shift)) | (newShort << shift);
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldShort = (oldWord >> shift) & 0xFFFF;
+            int newShort = (oldShort + value) & 0xFFFF;
+            newWord = (oldWord & ~mask) | (newShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFFFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -222,28 +212,50 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_SUB_U)]
     public static unsafe int I32AtomicRmw8SubU(byte* addr, int value)
     {
-        return I32AtomicRmw8AddU(addr, -value);
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int oldWord, newWord;
+        do
+        {
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldByte = (oldWord >> shift) & 0xFF;
+            int newByte = (oldByte - value) & 0xFF;
+            newWord = (oldWord & ~mask) | (newByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_SUB_U)]
     public static unsafe int I32AtomicRmw16SubU(ushort* addr, int value)
     {
-        return I32AtomicRmw16AddU(addr, -value);
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int oldWord, newWord;
+        do
+        {
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldShort = (oldWord >> shift) & 0xFFFF;
+            int newShort = (oldShort - value) & 0xFFFF;
+            newWord = (oldWord & ~mask) | (newShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFFFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_SUB_U)]
     public static unsafe long I64AtomicRmw8SubU(byte* addr, long value)
     {
-        return I32AtomicRmw8AddU(addr, -(int)value);
+        return I32AtomicRmw8SubU(addr, (int)value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_SUB_U)]
     public static unsafe long I64AtomicRmw16SubU(ushort* addr, long value)
     {
-        return I32AtomicRmw16AddU(addr, -(int)value);
+        return I32AtomicRmw16SubU(addr, (int)value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -273,32 +285,36 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_AND_U)]
     public static unsafe int I32AtomicRmw8AndU(byte* addr, int value)
     {
-        byte oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (byte)(oldVal & value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
-            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldByte = (oldWord >> shift) & 0xFF;
+            int newByte = oldByte & value;
+            newWord = (oldWord & ~mask) | (newByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_AND_U)]
     public static unsafe int I32AtomicRmw16AndU(ushort* addr, int value)
     {
-        ushort oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (ushort)(oldVal & value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
-            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldShort = (oldWord >> shift) & 0xFFFF;
+            int newShort = oldShort & value;
+            newWord = (oldWord & ~mask) | (newShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFFFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -342,32 +358,36 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_OR_U)]
     public static unsafe int I32AtomicRmw8OrU(byte* addr, int value)
     {
-        byte oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (byte)(oldVal | value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
-            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldByte = (oldWord >> shift) & 0xFF;
+            int newByte = oldByte | value;
+            newWord = (oldWord & ~mask) | (newByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_OR_U)]
     public static unsafe int I32AtomicRmw16OrU(ushort* addr, int value)
     {
-        ushort oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (ushort)(oldVal | value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
-            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldShort = (oldWord >> shift) & 0xFFFF;
+            int newShort = oldShort | value;
+            newWord = (oldWord & ~mask) | (newShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFFFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -423,32 +443,36 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_XOR_U)]
     public static unsafe int I32AtomicRmw8XorU(byte* addr, int value)
     {
-        byte oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (byte)(oldVal ^ value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
-            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldByte = (oldWord >> shift) & 0xFF;
+            int newByte = oldByte ^ value;
+            newWord = (oldWord & ~mask) | (newByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_XOR_U)]
     public static unsafe int I32AtomicRmw16XorU(ushort* addr, int value)
     {
-        ushort oldVal, newVal;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-            newVal = (ushort)(oldVal ^ value);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
-            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int oldShort = (oldWord >> shift) & 0xFFFF;
+            int newShort = oldShort ^ value;
+            newWord = (oldWord & ~mask) | (newShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFFFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -498,32 +522,34 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_XCHG_U)]
     public static unsafe int I32AtomicRmw8XchgU(byte* addr, int value)
     {
-        byte oldVal;
-        byte newVal = (byte)value;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int newByte = value & 0xFF;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
-            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
-            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            newWord = (oldWord & ~mask) | (newByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_XCHG_U)]
     public static unsafe int I32AtomicRmw16XchgU(ushort* addr, int value)
     {
-        ushort oldVal;
-        ushort newVal = (ushort)value;
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int newShort = value & 0xFFFF;
+        int oldWord, newWord;
         do
         {
-            oldVal = Volatile.Read(ref *addr);
-        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
-            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
-            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
-        return oldVal;
+            oldWord = Volatile.Read(ref *alignedAddr);
+            newWord = (oldWord & ~mask) | (newShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return (oldWord >> shift) & 0xFFFF;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -567,28 +593,42 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_CMPXCHG_U)]
     public static unsafe int I32AtomicRmw8CmpxchgU(byte* addr, int expected, int replacement)
     {
-        byte oldVal = Volatile.Read(ref *addr);
-        if (oldVal == (byte)expected)
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 3) * 8);
+        int mask = 0xFF << shift;
+        int expectedByte = expected & 0xFF;
+        int replacementByte = replacement & 0xFF;
+        int oldWord, newWord;
+        do
         {
-            Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-                ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), (byte)replacement),
-                ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), (byte)expected));
-        }
-        return Volatile.Read(ref *addr);
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int currentByte = (oldWord >> shift) & 0xFF;
+            if (currentByte != expectedByte)
+                return currentByte;
+            newWord = (oldWord & ~mask) | (replacementByte << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return expectedByte;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_CMPXCHG_U)]
     public static unsafe int I32AtomicRmw16CmpxchgU(ushort* addr, int expected, int replacement)
     {
-        ushort oldVal = Volatile.Read(ref *addr);
-        if (oldVal == (ushort)expected)
+        int* alignedAddr = (int*)((nint)addr & ~3);
+        int shift = (int)(((nint)addr & 2) * 8);
+        int mask = 0xFFFF << shift;
+        int expectedShort = expected & 0xFFFF;
+        int replacementShort = replacement & 0xFFFF;
+        int oldWord, newWord;
+        do
         {
-            Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
-                ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, (ushort)replacement),
-                ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, (ushort)expected));
-        }
-        return Volatile.Read(ref *addr);
+            oldWord = Volatile.Read(ref *alignedAddr);
+            int currentShort = (oldWord >> shift) & 0xFFFF;
+            if (currentShort != expectedShort)
+                return currentShort;
+            newWord = (oldWord & ~mask) | (replacementShort << shift);
+        } while (Interlocked.CompareExchange(ref *alignedAddr, newWord, oldWord) != oldWord);
+        return expectedShort;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -613,16 +653,11 @@ public partial class Lib
     }
 
     // ==================== Memory Atomic Wait/Notify Operations ====================
-    // These are used for thread synchronization (futex-like operations)
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_NOTIFY)]
     public static unsafe int MemoryAtomicNotify(int* addr, int count)
     {
-        // Wake up 'count' threads waiting on this address
-        // In .NET, we use Monitor for this
-        // Returns the number of threads woken up
-        // For single-threaded scenarios, this is effectively a no-op
         lock (GetWaitLock(addr))
         {
             if (count == int.MaxValue)
@@ -637,7 +672,6 @@ public partial class Lib
                 }
             }
         }
-        // Return count as an approximation (actual count may differ)
         return count;
     }
 
@@ -645,20 +679,13 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_WAIT32)]
     public static unsafe int MemoryAtomicWait32(int* addr, int expected, long timeout)
     {
-        // Wait on address if value equals expected
-        // Returns: 0 = woken by notify, 1 = value mismatch, 2 = timeout
         if (Volatile.Read(ref *addr) != expected)
-        {
-            return 1; // "not-equal"
-        }
+            return 1;
 
         lock (GetWaitLock(addr))
         {
-            // Double-check after acquiring lock
             if (Volatile.Read(ref *addr) != expected)
-            {
-                return 1; // "not-equal"
-            }
+                return 1;
 
             bool signaled;
             if (timeout < 0)
@@ -668,13 +695,11 @@ public partial class Lib
             }
             else
             {
-                // Timeout is in nanoseconds, convert to milliseconds
                 int timeoutMs = (int)(timeout / 1_000_000);
                 if (timeoutMs == 0 && timeout > 0) timeoutMs = 1;
                 signaled = Monitor.Wait(GetWaitLock(addr), timeoutMs);
             }
-
-            return signaled ? 0 : 2; // 0 = "ok", 2 = "timed-out"
+            return signaled ? 0 : 2;
         }
     }
 
@@ -682,20 +707,13 @@ public partial class Lib
     [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_WAIT64)]
     public static unsafe int MemoryAtomicWait64(long* addr, long expected, long timeout)
     {
-        // Wait on address if value equals expected
-        // Returns: 0 = woken by notify, 1 = value mismatch, 2 = timeout
         if (Interlocked.Read(ref *addr) != expected)
-        {
-            return 1; // "not-equal"
-        }
+            return 1;
 
         lock (GetWaitLock(addr))
         {
-            // Double-check after acquiring lock
             if (Interlocked.Read(ref *addr) != expected)
-            {
-                return 1; // "not-equal"
-            }
+                return 1;
 
             bool signaled;
             if (timeout < 0)
@@ -705,34 +723,27 @@ public partial class Lib
             }
             else
             {
-                // Timeout is in nanoseconds, convert to milliseconds
                 int timeoutMs = (int)(timeout / 1_000_000);
                 if (timeoutMs == 0 && timeout > 0) timeoutMs = 1;
                 signaled = Monitor.Wait(GetWaitLock(addr), timeoutMs);
             }
-
-            return signaled ? 0 : 2; // 0 = "ok", 2 = "timed-out"
+            return signaled ? 0 : 2;
         }
     }
 
-    // Simple lock table for wait/notify operations
-    // Using a fixed-size table with address hashing to avoid allocations
     private static readonly object[] WaitLocks = CreateWaitLocks();
 
     private static object[] CreateWaitLocks()
     {
         var locks = new object[256];
         for (int i = 0; i < locks.Length; i++)
-        {
             locks[i] = new object();
-        }
         return locks;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe object GetWaitLock(void* addr)
     {
-        // Hash the address to get a lock index
         var index = ((nint)addr >> 2) & 0xFF;
         return WaitLocks[index];
     }

--- a/Wasm2IL/Lib_Atomic.cs
+++ b/Wasm2IL/Lib_Atomic.cs
@@ -1,0 +1,738 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Wasm;
+
+namespace Wasm2IL;
+
+// All atomic/threading instructions are implemented here.
+public partial class Lib
+{
+    // ==================== Atomic Fence ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.ATOMIC_FENCE)]
+    public static void AtomicFence()
+    {
+        Thread.MemoryBarrier();
+    }
+
+    // ==================== Atomic Load Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD)]
+    public static unsafe int I32AtomicLoad(int* addr)
+    {
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD)]
+    public static unsafe long I64AtomicLoad(long* addr)
+    {
+        return Interlocked.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD8_U)]
+    public static unsafe int I32AtomicLoad8U(byte* addr)
+    {
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_LOAD16_U)]
+    public static unsafe int I32AtomicLoad16U(ushort* addr)
+    {
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD8_U)]
+    public static unsafe long I64AtomicLoad8U(byte* addr)
+    {
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD16_U)]
+    public static unsafe long I64AtomicLoad16U(ushort* addr)
+    {
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_LOAD32_U)]
+    public static unsafe long I64AtomicLoad32U(uint* addr)
+    {
+        return Volatile.Read(ref *addr);
+    }
+
+    // ==================== Atomic Store Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_STORE)]
+    public static unsafe void I32AtomicStore(int* addr, int value)
+    {
+        Volatile.Write(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE)]
+    public static unsafe void I64AtomicStore(long* addr, long value)
+    {
+        Interlocked.Exchange(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_STORE8)]
+    public static unsafe void I32AtomicStore8(byte* addr, int value)
+    {
+        Volatile.Write(ref *addr, (byte)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_STORE16)]
+    public static unsafe void I32AtomicStore16(ushort* addr, int value)
+    {
+        Volatile.Write(ref *addr, (ushort)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE8)]
+    public static unsafe void I64AtomicStore8(byte* addr, long value)
+    {
+        Volatile.Write(ref *addr, (byte)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE16)]
+    public static unsafe void I64AtomicStore16(ushort* addr, long value)
+    {
+        Volatile.Write(ref *addr, (ushort)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_STORE32)]
+    public static unsafe void I64AtomicStore32(uint* addr, long value)
+    {
+        Volatile.Write(ref *addr, (uint)value);
+    }
+
+    // ==================== Atomic RMW Add Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_ADD)]
+    public static unsafe int I32AtomicRmwAdd(int* addr, int value)
+    {
+        return Interlocked.Add(ref *addr, value) - value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_ADD)]
+    public static unsafe long I64AtomicRmwAdd(long* addr, long value)
+    {
+        return Interlocked.Add(ref *addr, value) - value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_ADD_U)]
+    public static unsafe int I32AtomicRmw8AddU(byte* addr, int value)
+    {
+        byte oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (byte)(oldVal + value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
+            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ReplaceByteInInt(int value, int byteIndex, byte newByte)
+    {
+        int shift = byteIndex * 8;
+        return (value & ~(0xFF << shift)) | (newByte << shift);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_ADD_U)]
+    public static unsafe int I32AtomicRmw16AddU(ushort* addr, int value)
+    {
+        ushort oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (ushort)(oldVal + value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
+            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ReplaceShortInInt(int value, int shortIndex, ushort newShort)
+    {
+        int shift = shortIndex * 16;
+        return (value & ~(0xFFFF << shift)) | (newShort << shift);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_ADD_U)]
+    public static unsafe long I64AtomicRmw8AddU(byte* addr, long value)
+    {
+        return I32AtomicRmw8AddU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_ADD_U)]
+    public static unsafe long I64AtomicRmw16AddU(ushort* addr, long value)
+    {
+        return I32AtomicRmw16AddU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_ADD_U)]
+    public static unsafe long I64AtomicRmw32AddU(uint* addr, long value)
+    {
+        return (uint)(Interlocked.Add(ref *(int*)addr, (int)value) - (int)value);
+    }
+
+    // ==================== Atomic RMW Sub Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_SUB)]
+    public static unsafe int I32AtomicRmwSub(int* addr, int value)
+    {
+        return Interlocked.Add(ref *addr, -value) + value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_SUB)]
+    public static unsafe long I64AtomicRmwSub(long* addr, long value)
+    {
+        return Interlocked.Add(ref *addr, -value) + value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_SUB_U)]
+    public static unsafe int I32AtomicRmw8SubU(byte* addr, int value)
+    {
+        return I32AtomicRmw8AddU(addr, -value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_SUB_U)]
+    public static unsafe int I32AtomicRmw16SubU(ushort* addr, int value)
+    {
+        return I32AtomicRmw16AddU(addr, -value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_SUB_U)]
+    public static unsafe long I64AtomicRmw8SubU(byte* addr, long value)
+    {
+        return I32AtomicRmw8AddU(addr, -(int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_SUB_U)]
+    public static unsafe long I64AtomicRmw16SubU(ushort* addr, long value)
+    {
+        return I32AtomicRmw16AddU(addr, -(int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_SUB_U)]
+    public static unsafe long I64AtomicRmw32SubU(uint* addr, long value)
+    {
+        return (uint)(Interlocked.Add(ref *(int*)addr, -(int)value) + (int)value);
+    }
+
+    // ==================== Atomic RMW And Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_AND)]
+    public static unsafe int I32AtomicRmwAnd(int* addr, int value)
+    {
+        return Interlocked.And(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_AND)]
+    public static unsafe long I64AtomicRmwAnd(long* addr, long value)
+    {
+        return Interlocked.And(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_AND_U)]
+    public static unsafe int I32AtomicRmw8AndU(byte* addr, int value)
+    {
+        byte oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (byte)(oldVal & value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
+            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_AND_U)]
+    public static unsafe int I32AtomicRmw16AndU(ushort* addr, int value)
+    {
+        ushort oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (ushort)(oldVal & value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
+            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_AND_U)]
+    public static unsafe long I64AtomicRmw8AndU(byte* addr, long value)
+    {
+        return I32AtomicRmw8AndU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_AND_U)]
+    public static unsafe long I64AtomicRmw16AndU(ushort* addr, long value)
+    {
+        return I32AtomicRmw16AndU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_AND_U)]
+    public static unsafe long I64AtomicRmw32AndU(uint* addr, long value)
+    {
+        return (uint)Interlocked.And(ref *(int*)addr, (int)value);
+    }
+
+    // ==================== Atomic RMW Or Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_OR)]
+    public static unsafe int I32AtomicRmwOr(int* addr, int value)
+    {
+        return Interlocked.Or(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_OR)]
+    public static unsafe long I64AtomicRmwOr(long* addr, long value)
+    {
+        return Interlocked.Or(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_OR_U)]
+    public static unsafe int I32AtomicRmw8OrU(byte* addr, int value)
+    {
+        byte oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (byte)(oldVal | value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
+            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_OR_U)]
+    public static unsafe int I32AtomicRmw16OrU(ushort* addr, int value)
+    {
+        ushort oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (ushort)(oldVal | value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
+            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_OR_U)]
+    public static unsafe long I64AtomicRmw8OrU(byte* addr, long value)
+    {
+        return I32AtomicRmw8OrU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_OR_U)]
+    public static unsafe long I64AtomicRmw16OrU(ushort* addr, long value)
+    {
+        return I32AtomicRmw16OrU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_OR_U)]
+    public static unsafe long I64AtomicRmw32OrU(uint* addr, long value)
+    {
+        return (uint)Interlocked.Or(ref *(int*)addr, (int)value);
+    }
+
+    // ==================== Atomic RMW Xor Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_XOR)]
+    public static unsafe int I32AtomicRmwXor(int* addr, int value)
+    {
+        int oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = oldVal ^ value;
+        } while (Interlocked.CompareExchange(ref *addr, newVal, oldVal) != oldVal);
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_XOR)]
+    public static unsafe long I64AtomicRmwXor(long* addr, long value)
+    {
+        long oldVal, newVal;
+        do
+        {
+            oldVal = Interlocked.Read(ref *addr);
+            newVal = oldVal ^ value;
+        } while (Interlocked.CompareExchange(ref *addr, newVal, oldVal) != oldVal);
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_XOR_U)]
+    public static unsafe int I32AtomicRmw8XorU(byte* addr, int value)
+    {
+        byte oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (byte)(oldVal ^ value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
+            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_XOR_U)]
+    public static unsafe int I32AtomicRmw16XorU(ushort* addr, int value)
+    {
+        ushort oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+            newVal = (ushort)(oldVal ^ value);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
+            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_XOR_U)]
+    public static unsafe long I64AtomicRmw8XorU(byte* addr, long value)
+    {
+        return I32AtomicRmw8XorU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_XOR_U)]
+    public static unsafe long I64AtomicRmw16XorU(ushort* addr, long value)
+    {
+        return I32AtomicRmw16XorU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_XOR_U)]
+    public static unsafe long I64AtomicRmw32XorU(uint* addr, long value)
+    {
+        int oldVal, newVal;
+        do
+        {
+            oldVal = Volatile.Read(ref *(int*)addr);
+            newVal = oldVal ^ (int)value;
+        } while (Interlocked.CompareExchange(ref *(int*)addr, newVal, oldVal) != oldVal);
+        return (uint)oldVal;
+    }
+
+    // ==================== Atomic RMW Exchange Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_XCHG)]
+    public static unsafe int I32AtomicRmwXchg(int* addr, int value)
+    {
+        return Interlocked.Exchange(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_XCHG)]
+    public static unsafe long I64AtomicRmwXchg(long* addr, long value)
+    {
+        return Interlocked.Exchange(ref *addr, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_XCHG_U)]
+    public static unsafe int I32AtomicRmw8XchgU(byte* addr, int value)
+    {
+        byte oldVal;
+        byte newVal = (byte)value;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), newVal),
+            ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal))
+            != ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_XCHG_U)]
+    public static unsafe int I32AtomicRmw16XchgU(ushort* addr, int value)
+    {
+        ushort oldVal;
+        ushort newVal = (ushort)value;
+        do
+        {
+            oldVal = Volatile.Read(ref *addr);
+        } while (Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, newVal),
+            ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal))
+            != ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, oldVal));
+        return oldVal;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_XCHG_U)]
+    public static unsafe long I64AtomicRmw8XchgU(byte* addr, long value)
+    {
+        return I32AtomicRmw8XchgU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_XCHG_U)]
+    public static unsafe long I64AtomicRmw16XchgU(ushort* addr, long value)
+    {
+        return I32AtomicRmw16XchgU(addr, (int)value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_XCHG_U)]
+    public static unsafe long I64AtomicRmw32XchgU(uint* addr, long value)
+    {
+        return (uint)Interlocked.Exchange(ref *(int*)addr, (int)value);
+    }
+
+    // ==================== Atomic RMW Compare-Exchange Operations ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW_CMPXCHG)]
+    public static unsafe int I32AtomicRmwCmpxchg(int* addr, int expected, int replacement)
+    {
+        return Interlocked.CompareExchange(ref *addr, replacement, expected);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW_CMPXCHG)]
+    public static unsafe long I64AtomicRmwCmpxchg(long* addr, long expected, long replacement)
+    {
+        return Interlocked.CompareExchange(ref *addr, replacement, expected);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW8_CMPXCHG_U)]
+    public static unsafe int I32AtomicRmw8CmpxchgU(byte* addr, int expected, int replacement)
+    {
+        byte oldVal = Volatile.Read(ref *addr);
+        if (oldVal == (byte)expected)
+        {
+            Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+                ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), (byte)replacement),
+                ReplaceByteInInt(*(int*)((nint)addr & ~3), (int)((nint)addr & 3), (byte)expected));
+        }
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I32_ATOMIC_RMW16_CMPXCHG_U)]
+    public static unsafe int I32AtomicRmw16CmpxchgU(ushort* addr, int expected, int replacement)
+    {
+        ushort oldVal = Volatile.Read(ref *addr);
+        if (oldVal == (ushort)expected)
+        {
+            Interlocked.CompareExchange(ref *(int*)((nint)addr & ~3),
+                ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, (ushort)replacement),
+                ReplaceShortInInt(*(int*)((nint)addr & ~3), ((nint)addr & 2) != 0 ? 1 : 0, (ushort)expected));
+        }
+        return Volatile.Read(ref *addr);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW8_CMPXCHG_U)]
+    public static unsafe long I64AtomicRmw8CmpxchgU(byte* addr, long expected, long replacement)
+    {
+        return I32AtomicRmw8CmpxchgU(addr, (int)expected, (int)replacement);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW16_CMPXCHG_U)]
+    public static unsafe long I64AtomicRmw16CmpxchgU(ushort* addr, long expected, long replacement)
+    {
+        return I32AtomicRmw16CmpxchgU(addr, (int)expected, (int)replacement);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.I64_ATOMIC_RMW32_CMPXCHG_U)]
+    public static unsafe long I64AtomicRmw32CmpxchgU(uint* addr, long expected, long replacement)
+    {
+        return (uint)Interlocked.CompareExchange(ref *(int*)addr, (int)replacement, (int)expected);
+    }
+
+    // ==================== Memory Atomic Wait/Notify Operations ====================
+    // These are used for thread synchronization (futex-like operations)
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_NOTIFY)]
+    public static unsafe int MemoryAtomicNotify(int* addr, int count)
+    {
+        // Wake up 'count' threads waiting on this address
+        // In .NET, we use Monitor for this
+        // Returns the number of threads woken up
+        // For single-threaded scenarios, this is effectively a no-op
+        lock (GetWaitLock(addr))
+        {
+            if (count == int.MaxValue)
+            {
+                Monitor.PulseAll(GetWaitLock(addr));
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Monitor.Pulse(GetWaitLock(addr));
+                }
+            }
+        }
+        // Return count as an approximation (actual count may differ)
+        return count;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_WAIT32)]
+    public static unsafe int MemoryAtomicWait32(int* addr, int expected, long timeout)
+    {
+        // Wait on address if value equals expected
+        // Returns: 0 = woken by notify, 1 = value mismatch, 2 = timeout
+        if (Volatile.Read(ref *addr) != expected)
+        {
+            return 1; // "not-equal"
+        }
+
+        lock (GetWaitLock(addr))
+        {
+            // Double-check after acquiring lock
+            if (Volatile.Read(ref *addr) != expected)
+            {
+                return 1; // "not-equal"
+            }
+
+            bool signaled;
+            if (timeout < 0)
+            {
+                Monitor.Wait(GetWaitLock(addr));
+                signaled = true;
+            }
+            else
+            {
+                // Timeout is in nanoseconds, convert to milliseconds
+                int timeoutMs = (int)(timeout / 1_000_000);
+                if (timeoutMs == 0 && timeout > 0) timeoutMs = 1;
+                signaled = Monitor.Wait(GetWaitLock(addr), timeoutMs);
+            }
+
+            return signaled ? 0 : 2; // 0 = "ok", 2 = "timed-out"
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [WasmOpcode(AtomicInstruction.MEMORY_ATOMIC_WAIT64)]
+    public static unsafe int MemoryAtomicWait64(long* addr, long expected, long timeout)
+    {
+        // Wait on address if value equals expected
+        // Returns: 0 = woken by notify, 1 = value mismatch, 2 = timeout
+        if (Interlocked.Read(ref *addr) != expected)
+        {
+            return 1; // "not-equal"
+        }
+
+        lock (GetWaitLock(addr))
+        {
+            // Double-check after acquiring lock
+            if (Interlocked.Read(ref *addr) != expected)
+            {
+                return 1; // "not-equal"
+            }
+
+            bool signaled;
+            if (timeout < 0)
+            {
+                Monitor.Wait(GetWaitLock(addr));
+                signaled = true;
+            }
+            else
+            {
+                // Timeout is in nanoseconds, convert to milliseconds
+                int timeoutMs = (int)(timeout / 1_000_000);
+                if (timeoutMs == 0 && timeout > 0) timeoutMs = 1;
+                signaled = Monitor.Wait(GetWaitLock(addr), timeoutMs);
+            }
+
+            return signaled ? 0 : 2; // 0 = "ok", 2 = "timed-out"
+        }
+    }
+
+    // Simple lock table for wait/notify operations
+    // Using a fixed-size table with address hashing to avoid allocations
+    private static readonly object[] WaitLocks = CreateWaitLocks();
+
+    private static object[] CreateWaitLocks()
+    {
+        var locks = new object[256];
+        for (int i = 0; i < locks.Length; i++)
+        {
+            locks[i] = new object();
+        }
+        return locks;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe object GetWaitLock(void* addr)
+    {
+        // Hash the address to get a lock index
+        var index = ((nint)addr >> 2) & 0xFF;
+        return WaitLocks[index];
+    }
+}

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -47,7 +47,7 @@ public class Transformer
         var tf = new Transformer();
         foreach (var item in environment)
             tf.LoadImportModule(item.moduleName, item.lib);
-        return tf.LoadWasmAssembly(wasmModulePath, "C");
+        return tf.LoadWasmAssembly(wasmModulePath, "C", Path.ChangeExtension(wasmModulePath, "dll"));
     }
     
     public void LoadImportModule(string moduleName, Type type)
@@ -189,6 +189,7 @@ public class Transformer
         functionTable = new FieldDefinition("FunctionTable", FieldAttributes.Static | FieldAttributes.Public,
             asm.MainModule.TypeSystem.IntPtr.MakeArrayType());
         cls.Fields.Add(functionTable);
+       
         var cctor = new MethodDefinition(".cctor",
             MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Static |
             MethodAttributes.RTSpecialName | MethodAttributes.SpecialName, asm.MainModule.TypeSystem.Void);
@@ -422,7 +423,7 @@ public class Transformer
             il.Emit(OpCodes.Ldc_I4, (int) fncCnt + 1);
             il.Emit(OpCodes.Newarr, def.MainModule.TypeSystem.IntPtr);
             il.Emit(OpCodes.Stsfld, functionTable);
-
+            
             for (var i2 = 0; i2 < fncCnt; i2++)
             {
                 il.Emit(OpCodes.Ldsfld, functionTable);
@@ -456,6 +457,13 @@ public class Transformer
                 {
                     il.Emit(OpCodes.Ldftn, funcDecl[(uint) (funcId - importFuncs.Count)].Method);
                     il.Emit(OpCodes.Stelem_I);
+                    
+                    var attrCtor = def.MainModule.ImportReference(typeof(FunctionExportAttribute).GetConstructor([typeof(int)]));
+                    var attr = new CustomAttribute(attrCtor);
+                    attr.ConstructorArguments.Add(new CustomAttributeArgument(this.i32Type, (int)(i2 + elementOffset)));
+                    funcDecl[(uint) (funcId - importFuncs.Count)].Method.CustomAttributes.Add(attr);
+
+
                 }
             }
 
@@ -1562,15 +1570,20 @@ public class Transformer
                             ctx.EmitCallForOpcode(ainstr);
                             break;
                         }
+                        if (ainstr == AtomicInstruction.I32_ATOMIC_RMW_ADD)
+                        {
+                            ctx.EmitCallForOpcode(ainstr);
+                            break;
+                        }
 
                         // All other atomic instructions have memarg (align + offset)
                         reader.ReadU32Leb(); // align hint (ignored for now)
-                        var offset = reader.ReadU32Leb();
+                        var atomicOffset = reader.ReadU32Leb();
 
                         // Load address computation: stack value + offset + memory base
-                        if (offset != 0)
+                        if (atomicOffset != 0)
                         {
-                            il.Emit(IlOp.Ldc_I4, (int) offset);
+                            il.Emit(IlOp.Ldc_I4, (int) atomicOffset);
                             il.Emit(IlOp.Add);
                         }
                         ctx.LoadMemory();
@@ -1584,10 +1597,7 @@ public class Transformer
 
                     case WOp.VECTOR_INSTRUCTION:
                         var instr2 = (VectorInstructions) reader.ReadU32Leb();
-                        if (instr2.ToString().Contains("RELAXED"))
-                        {
-                        }
-
+                        
                         switch (instr2)
                         {
                             case VectorInstructions.V128_STORE:
@@ -2092,6 +2102,7 @@ public class Transformer
                 Method = new MethodDefinition("func" + i, MethodAttributes.Static | MethodAttributes.Public,
                     def.MainModule.TypeSystem.Void)
             };
+            
         }
     }
 

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1567,29 +1567,7 @@ public class Transformer
                         if (ainstr == AtomicInstruction.ATOMIC_FENCE)
                         {
                             reader.ReadU8(); // reserved byte, must be 0x00
-                            ctx.EmitCallForOpcode(ainstr);
-                            break;
                         }
-                        if (ainstr == AtomicInstruction.I32_ATOMIC_RMW_ADD)
-                        {
-                            ctx.EmitCallForOpcode(ainstr);
-                            break;
-                        }
-
-                        // All other atomic instructions have memarg (align + offset)
-                        reader.ReadU32Leb(); // align hint (ignored for now)
-                        var atomicOffset = reader.ReadU32Leb();
-
-                        // Load address computation: stack value + offset + memory base
-                        if (atomicOffset != 0)
-                        {
-                            il.Emit(IlOp.Ldc_I4, (int) atomicOffset);
-                            il.Emit(IlOp.Add);
-                        }
-                        ctx.LoadMemory();
-                        il.Emit(IlOp.Add);
-
-                        ctx.PopType(); // pop the address
 
                         ctx.EmitCallForOpcode(ainstr);
                         break;

--- a/Wasm2IL/Transformer.cs
+++ b/Wasm2IL/Transformer.cs
@@ -1551,6 +1551,37 @@ public class Transformer
                         ctx.EmitCallForOpcode(einstr);
                         break;
 
+                    case WOp.ATOMIC_INSTRUCTION:
+                    {
+                        var ainstr = (AtomicInstruction) reader.ReadU32Leb();
+
+                        // Handle atomic.fence specially - it just has a reserved byte
+                        if (ainstr == AtomicInstruction.ATOMIC_FENCE)
+                        {
+                            reader.ReadU8(); // reserved byte, must be 0x00
+                            ctx.EmitCallForOpcode(ainstr);
+                            break;
+                        }
+
+                        // All other atomic instructions have memarg (align + offset)
+                        reader.ReadU32Leb(); // align hint (ignored for now)
+                        var offset = reader.ReadU32Leb();
+
+                        // Load address computation: stack value + offset + memory base
+                        if (offset != 0)
+                        {
+                            il.Emit(IlOp.Ldc_I4, (int) offset);
+                            il.Emit(IlOp.Add);
+                        }
+                        ctx.LoadMemory();
+                        il.Emit(IlOp.Add);
+
+                        ctx.PopType(); // pop the address
+
+                        ctx.EmitCallForOpcode(ainstr);
+                        break;
+                    }
+
                     case WOp.VECTOR_INSTRUCTION:
                         var instr2 = (VectorInstructions) reader.ReadU32Leb();
                         if (instr2.ToString().Contains("RELAXED"))

--- a/Wasm2IL/WasmSpec/Instruction.cs
+++ b/Wasm2IL/WasmSpec/Instruction.cs
@@ -189,6 +189,7 @@ namespace Wasm
         REF_FUNC = 0xD2,
         EXTENDED_INSTRUCTION = 0xFC,
         VECTOR_INSTRUCTION = 0xFD,
+        ATOMIC_INSTRUCTION = 0xFE,
     }
 
     public enum ExtendedInstruction
@@ -432,5 +433,95 @@ namespace Wasm
         I16X8_RELAXED_Q15MULR_S = 0x111,
         I16X8_RELAXED_DOT_I8X16_I7X16_S = 0x112,
         I32X4_RELAXED_DOT_I8X16_I7X16_ADD_S = 0x113,
+    }
+
+    public enum AtomicInstruction
+    {
+        // Memory Atomic Notify/Wait
+        MEMORY_ATOMIC_NOTIFY = 0x00,
+        MEMORY_ATOMIC_WAIT32 = 0x01,
+        MEMORY_ATOMIC_WAIT64 = 0x02,
+        ATOMIC_FENCE = 0x03,
+
+        // Atomic Load Operations
+        I32_ATOMIC_LOAD = 0x10,
+        I64_ATOMIC_LOAD = 0x11,
+        I32_ATOMIC_LOAD8_U = 0x12,
+        I32_ATOMIC_LOAD16_U = 0x13,
+        I64_ATOMIC_LOAD8_U = 0x14,
+        I64_ATOMIC_LOAD16_U = 0x15,
+        I64_ATOMIC_LOAD32_U = 0x16,
+
+        // Atomic Store Operations
+        I32_ATOMIC_STORE = 0x17,
+        I64_ATOMIC_STORE = 0x18,
+        I32_ATOMIC_STORE8 = 0x19,
+        I32_ATOMIC_STORE16 = 0x1A,
+        I64_ATOMIC_STORE8 = 0x1B,
+        I64_ATOMIC_STORE16 = 0x1C,
+        I64_ATOMIC_STORE32 = 0x1D,
+
+        // Atomic RMW Add Operations
+        I32_ATOMIC_RMW_ADD = 0x1E,
+        I64_ATOMIC_RMW_ADD = 0x1F,
+        I32_ATOMIC_RMW8_ADD_U = 0x20,
+        I32_ATOMIC_RMW16_ADD_U = 0x21,
+        I64_ATOMIC_RMW8_ADD_U = 0x22,
+        I64_ATOMIC_RMW16_ADD_U = 0x23,
+        I64_ATOMIC_RMW32_ADD_U = 0x24,
+
+        // Atomic RMW Sub Operations
+        I32_ATOMIC_RMW_SUB = 0x25,
+        I64_ATOMIC_RMW_SUB = 0x26,
+        I32_ATOMIC_RMW8_SUB_U = 0x27,
+        I32_ATOMIC_RMW16_SUB_U = 0x28,
+        I64_ATOMIC_RMW8_SUB_U = 0x29,
+        I64_ATOMIC_RMW16_SUB_U = 0x2A,
+        I64_ATOMIC_RMW32_SUB_U = 0x2B,
+
+        // Atomic RMW And Operations
+        I32_ATOMIC_RMW_AND = 0x2C,
+        I64_ATOMIC_RMW_AND = 0x2D,
+        I32_ATOMIC_RMW8_AND_U = 0x2E,
+        I32_ATOMIC_RMW16_AND_U = 0x2F,
+        I64_ATOMIC_RMW8_AND_U = 0x30,
+        I64_ATOMIC_RMW16_AND_U = 0x31,
+        I64_ATOMIC_RMW32_AND_U = 0x32,
+
+        // Atomic RMW Or Operations
+        I32_ATOMIC_RMW_OR = 0x33,
+        I64_ATOMIC_RMW_OR = 0x34,
+        I32_ATOMIC_RMW8_OR_U = 0x35,
+        I32_ATOMIC_RMW16_OR_U = 0x36,
+        I64_ATOMIC_RMW8_OR_U = 0x37,
+        I64_ATOMIC_RMW16_OR_U = 0x38,
+        I64_ATOMIC_RMW32_OR_U = 0x39,
+
+        // Atomic RMW Xor Operations
+        I32_ATOMIC_RMW_XOR = 0x3A,
+        I64_ATOMIC_RMW_XOR = 0x3B,
+        I32_ATOMIC_RMW8_XOR_U = 0x3C,
+        I32_ATOMIC_RMW16_XOR_U = 0x3D,
+        I64_ATOMIC_RMW8_XOR_U = 0x3E,
+        I64_ATOMIC_RMW16_XOR_U = 0x3F,
+        I64_ATOMIC_RMW32_XOR_U = 0x40,
+
+        // Atomic RMW Exchange Operations
+        I32_ATOMIC_RMW_XCHG = 0x41,
+        I64_ATOMIC_RMW_XCHG = 0x42,
+        I32_ATOMIC_RMW8_XCHG_U = 0x43,
+        I32_ATOMIC_RMW16_XCHG_U = 0x44,
+        I64_ATOMIC_RMW8_XCHG_U = 0x45,
+        I64_ATOMIC_RMW16_XCHG_U = 0x46,
+        I64_ATOMIC_RMW32_XCHG_U = 0x47,
+
+        // Atomic RMW Compare-Exchange Operations
+        I32_ATOMIC_RMW_CMPXCHG = 0x48,
+        I64_ATOMIC_RMW_CMPXCHG = 0x49,
+        I32_ATOMIC_RMW8_CMPXCHG_U = 0x4A,
+        I32_ATOMIC_RMW16_CMPXCHG_U = 0x4B,
+        I64_ATOMIC_RMW8_CMPXCHG_U = 0x4C,
+        I64_ATOMIC_RMW16_CMPXCHG_U = 0x4D,
+        I64_ATOMIC_RMW32_CMPXCHG_U = 0x4E,
     }
 }


### PR DESCRIPTION
Implement support for the WebAssembly threading proposal (0xFE prefix):
- Add AtomicInstruction enum with all threading opcodes
- Add ATOMIC_INSTRUCTION prefix (0xFE) to Instruction enum
- Create Lib_Atomic.cs with atomic operation implementations
- Add parsing for 0xFE prefix in Transformer.cs

Includes implementations for:
- Atomic loads (i32/i64, various sizes)
- Atomic stores (i32/i64, various sizes)
- Atomic RMW operations (add, sub, and, or, xor, xchg, cmpxchg)
- Memory barrier (atomic.fence)
- Wait/notify operations for thread synchronization